### PR TITLE
refactor: 해시태그 이벤트 개선

### DIFF
--- a/src/app/(pages)/challenge/create/_components/HashTags.test.tsx
+++ b/src/app/(pages)/challenge/create/_components/HashTags.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import HashTags from './HashTags';
 
+
 describe('HashTags Component', () => {
   const mockOnChange = jest.fn();
 
@@ -17,7 +18,7 @@ describe('HashTags Component', () => {
   test('adds a hashtag when Enter is pressed', () => {
     const input = screen.getByTestId('hashtag-input');
     fireEvent.change(input, { target: { value: 'test' } });
-    fireEvent.keyUp(input, { key: 'Enter' });
+    fireEvent.keyDown(input, { key: 'Enter' });
 
     expect(mockOnChange).toHaveBeenCalledWith(['test']);
     expect(screen.getByText('#test')).toBeInTheDocument();
@@ -26,8 +27,8 @@ describe('HashTags Component', () => {
 
   test('adds a hashtag when space is pressed', () => {
     const input = screen.getByTestId('hashtag-input');
-    fireEvent.change(input, { target: { value: 'space ' } });
-    fireEvent.keyUp(input, { key: ' ' });
+    fireEvent.change(input, { target: { value: 'space' } });
+    fireEvent.keyDown(input, { key: ' ' });
 
     expect(mockOnChange).toHaveBeenCalledWith(['space']);
     expect(screen.getByText('#space')).toBeInTheDocument();
@@ -36,8 +37,8 @@ describe('HashTags Component', () => {
 
   test('adds a hashtag when any of "#" is pressed', () => {
     const input = screen.getByTestId('hashtag-input');
-    fireEvent.change(input, { target: { value: 'hashtag#' } });
-    fireEvent.keyUp(input, { key: '#' });
+    fireEvent.change(input, { target: { value: 'hashtag' } });
+    fireEvent.keyDown(input, { key: '#' });
 
     expect(mockOnChange).toHaveBeenCalledWith(['hashtag']);
     expect(screen.getByText('#hashtag')).toBeInTheDocument();
@@ -46,8 +47,8 @@ describe('HashTags Component', () => {
 
   test('adds a hashtag when comma is pressed', () => {
     const input = screen.getByTestId('hashtag-input');
-    fireEvent.change(input, { target: { value: 'comma,' } });
-    fireEvent.keyUp(input, { key: ',' });
+    fireEvent.change(input, { target: { value: 'comma' } });
+    fireEvent.keyDown(input, { key: ',' });
 
     expect(mockOnChange).toHaveBeenCalledWith(['comma']);
     expect(screen.getByText('#comma')).toBeInTheDocument();
@@ -57,7 +58,7 @@ describe('HashTags Component', () => {
   test('does not add hashtags when the input is empty', () => {
     const input = screen.getByTestId('hashtag-input');
     fireEvent.change(input, { target: { value: undefined } });
-    fireEvent.keyUp(input, { key: 'Enter' });
+    fireEvent.keyDown(input, { key: 'Enter' });
 
     expect(screen.getByText('0/50')).toBeInTheDocument();
   });
@@ -65,7 +66,7 @@ describe('HashTags Component', () => {
   test('removes a hashtag when clicked', () => {
     const input = screen.getByTestId('hashtag-input');
     fireEvent.change(input, { target: { value: 'test' } });
-    fireEvent.keyUp(input, { key: 'Enter' });
+    fireEvent.keyDown(input, { key: 'Enter' });
 
     const hashtag = screen.getByText('#test');
     fireEvent.click(hashtag);
@@ -78,7 +79,7 @@ describe('HashTags Component', () => {
   test('removes a hashtag when Backspace is pressed', () => {
     const input = screen.getByTestId('hashtag-input');
     fireEvent.change(input, { target: { value: 'test' } });
-    fireEvent.keyUp(input, { key: 'Enter' });
+    fireEvent.keyDown(input, { key: 'Enter' });
     fireEvent.keyDown(input, { key: 'Backspace' });
 
     expect(mockOnChange).toHaveBeenCalledWith([]);
@@ -98,7 +99,7 @@ describe('HashTags Component', () => {
   test('does not add sperator characters as hashtags', () => {
     const input = screen.getByTestId('hashtag-input');
     fireEvent.change(input, { target: { value: '#' } });
-    fireEvent.keyUp(input, { key: '#' });
+    fireEvent.keyDown(input, { key: '#' });
 
     expect(input).toHaveValue('');
   });
@@ -108,7 +109,7 @@ describe('HashTags Component', () => {
     const inputContainer = screen.getByTestId('hashtag-input-container');
 
     fireEvent.change(input, { target: { value: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWY' } });
-    fireEvent.keyUp(input, { key: 'Enter' });
+    fireEvent.keyDown(input, { key: 'Enter' });
 
     expect(screen.queryByText('#abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWY')).toBeInTheDocument();
     expect(inputContainer).toHaveClass('invisible h-0');

--- a/src/app/(pages)/challenge/create/_components/HashTags.test.tsx
+++ b/src/app/(pages)/challenge/create/_components/HashTags.test.tsx
@@ -2,20 +2,20 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import HashTags from './HashTags';
 
 
-describe('HashTags Component', () => {
+describe('HashTags 컴포넌트', () => {
   const mockOnChange = jest.fn();
 
   beforeEach(() => {
     render(<HashTags value={[]} onChange={mockOnChange} />);
   });
 
-  test('default: renders input and displays hashtag count', () => {
+  test('기본: 입력 필드와 해시태그 개수를 렌더링한다', () => {
     const input = screen.getByTestId('hashtag-input');
     expect(input).toBeInTheDocument();
     expect(screen.getByText('0/50')).toBeInTheDocument();
   });
 
-  test('adds a hashtag when Enter is pressed', () => {
+  test('Enter 키를 누르면 해시태그를 추가한다', () => {
     const input = screen.getByTestId('hashtag-input');
     fireEvent.change(input, { target: { value: 'test' } });
     fireEvent.keyDown(input, { key: 'Enter' });
@@ -25,7 +25,7 @@ describe('HashTags Component', () => {
     expect(screen.getByText('4/50')).toBeInTheDocument();
   });
 
-  test('adds a hashtag when space is pressed', () => {
+  test('Space 키를 누르면 해시태그를 추가한다', () => {
     const input = screen.getByTestId('hashtag-input');
     fireEvent.change(input, { target: { value: 'space' } });
     fireEvent.keyDown(input, { key: ' ' });
@@ -35,7 +35,7 @@ describe('HashTags Component', () => {
     expect(screen.getByText('5/50')).toBeInTheDocument();
   });
 
-  test('adds a hashtag when any of "#" is pressed', () => {
+  test('# 키를 누르면 해시태그를 추가한다', () => {
     const input = screen.getByTestId('hashtag-input');
     fireEvent.change(input, { target: { value: 'hashtag' } });
     fireEvent.keyDown(input, { key: '#' });
@@ -45,7 +45,7 @@ describe('HashTags Component', () => {
     expect(screen.getByText('7/50')).toBeInTheDocument();
   });
 
-  test('adds a hashtag when comma is pressed', () => {
+  test(', 키를 누르면 해시태그를 추가한다', () => {
     const input = screen.getByTestId('hashtag-input');
     fireEvent.change(input, { target: { value: 'comma' } });
     fireEvent.keyDown(input, { key: ',' });
@@ -55,7 +55,7 @@ describe('HashTags Component', () => {
     expect(screen.getByText('5/50')).toBeInTheDocument();
   });
 
-  test('does not add hashtags when the input is empty', () => {
+  test('입력이 비어 있으면 해시태그를 추가하지 않는다', () => {
     const input = screen.getByTestId('hashtag-input');
     fireEvent.change(input, { target: { value: undefined } });
     fireEvent.keyDown(input, { key: 'Enter' });
@@ -63,7 +63,7 @@ describe('HashTags Component', () => {
     expect(screen.getByText('0/50')).toBeInTheDocument();
   });
 
-  test('removes a hashtag when clicked', () => {
+  test('해시태그를 클릭하면 삭제된다', () => {
     const input = screen.getByTestId('hashtag-input');
     fireEvent.change(input, { target: { value: 'test' } });
     fireEvent.keyDown(input, { key: 'Enter' });
@@ -76,7 +76,7 @@ describe('HashTags Component', () => {
     expect(screen.getByText('0/50')).toBeInTheDocument();
   });
 
-  test('removes a hashtag when Backspace is pressed', () => {
+  test('Backspace 키를 누르면 마지막 해시태그를 삭제한다', () => {
     const input = screen.getByTestId('hashtag-input');
     fireEvent.change(input, { target: { value: 'test' } });
     fireEvent.keyDown(input, { key: 'Enter' });
@@ -87,7 +87,7 @@ describe('HashTags Component', () => {
     expect(screen.getByText('0/50')).toBeInTheDocument();
   });
 
-  test('does not add empty hashtags', () => {
+  test('빈 값을 해시태그로 추가하지 않는다', () => {
     const input = screen.getByTestId('hashtag-input');
     fireEvent.change(input, { target: { value: '' } });
 
@@ -96,7 +96,7 @@ describe('HashTags Component', () => {
     expect(screen.getByText('0/50')).toBeInTheDocument();
   });
 
-  test('does not add sperator characters as hashtags', () => {
+  test('구분자 문자를 해시태그로 추가하지 않는다', () => {
     const input = screen.getByTestId('hashtag-input');
     fireEvent.change(input, { target: { value: '#' } });
     fireEvent.keyDown(input, { key: '#' });
@@ -104,7 +104,7 @@ describe('HashTags Component', () => {
     expect(input).toHaveValue('');
   });
 
-  test('input is invisible when the hashtag count is over 50', () => {
+  test('총 해시태그 문자열의 길이가 50을 초과하면 입력 필드가 숨겨진다', () => {
     const input = screen.getByTestId('hashtag-input');
     const inputContainer = screen.getByTestId('hashtag-input-container');
 

--- a/src/app/(pages)/challenge/create/_components/HashTags.tsx
+++ b/src/app/(pages)/challenge/create/_components/HashTags.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 
+
 const MAX_HASHTAG_LENGTH = 50;
 
 export default function HashTags({ value, onChange }: { value: string[]; onChange: (value: string[]) => void }) {
@@ -72,18 +73,15 @@ export default function HashTags({ value, onChange }: { value: string[]; onChang
             disabled={hashtagTextLength >= MAX_HASHTAG_LENGTH}
             onKeyDown={(e) => {
               if (e.key === 'Enter') {
+                handleHashtagInputKeyUp(getValues('hashtagInput'));
                 e.preventDefault();
               }
               if (e.key === 'Backspace' && hashtagInputLength === 0) {
                 const lastHashtag = Array.from(hashtags).pop();
                 handleRemoveHashtag(lastHashtag);
               }
-            }}
-            onKeyUp={(e) => {
-              if (e.key === 'Enter') {
+              if (e.key === ' ' || e.key === '#' || e.key === ',') {
                 handleHashtagInputKeyUp(getValues('hashtagInput'));
-              } else if (e.key === ' ' || e.key === '#' || e.key === ',') {
-                handleHashtagInputKeyUp(getValues('hashtagInput').slice(0, -1));
               }
             }}
             {...register('hashtagInput')}


### PR DESCRIPTION
## 작업 내용
- onKeyUp과 onKeyDown이 혼용되어 있던 코드를 onKeyDown으로 통일했습니다.
- 로직에 맞춰 테스트코드의 event fire 또한 수정완료했습니다.
- test suite, test case 이름을 한글로 변경했습니다.

## 테스트 커버리지 
<img width="854" alt="image" src="https://github.com/user-attachments/assets/027b96a0-10f4-40ad-ae8b-8e2a36458f37">
