### PR TITLE
feat: Challenge api 관련 작업

### DIFF
--- a/db.json
+++ b/db.json
@@ -1,0 +1,30 @@
+{
+  "challenge": [
+    {
+      "id": 1,
+      "challengeId": 1,
+      "name": "test",
+      "backgroundImage": "https://image.utoimage.com/preview/cp872722/2022/12/202212008462_500.jpg",
+      "currentParticipants": 0,
+      "maxParticipants": 3,
+      "tags": ["댕댕이"],
+      "createdAt": "2024-12-19T22:20:14.114281",
+      "creatorUserUuid": "75ab190b-6998-41c5-98d2-ea70df102264\t",
+      "participants": null,
+      "public": true
+    },
+    {
+      "id": 2,
+      "challengeId": 2,
+      "name": "test2",
+      "backgroundImage": "https://www.google.com/url?sa=i&url=https%3A%2F%2Fwww.imin.sg%2Fen%2Fo2o-offline-2-online-system%2F&psig=AOvVaw3xdQzkxRiFQhdAaYQlD9HW&ust=1734423534473000&source=images&cd=vfe&opi=89978449&ved=0CBQQjRxqFwoTCLjmiaftq4oDFQAAAAAdAAAAABAE",
+      "currentParticipants": 0,
+      "maxParticipants": 3,
+      "tags": [],
+      "createdAt": "2024-12-20T22:20:14.114281",
+      "creatorUserUuid": "75ab190b-6998-41c5-98d2-ea70df102264\t",
+      "participants": null,
+      "public": true
+    }
+  ]
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -6,6 +6,14 @@ const nextConfig = {
         protocol: 'https',
         hostname: 'jaksimimage2.s3.ap-northeast-2.amazonaws.com',
       },
+      {
+        protocol: 'https',
+        hostname: 'www.google.com',
+      },
+      {
+        protocol: 'https',
+        hostname: 'image.utoimage.com',
+      },
     ],
   },
   webpack: (config) => {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint-staged": "lint-staged",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "start:mock": "json-server --watch db.json --port 3001"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/src/app/(pages)/auth/sign-up/_components/SignUp.tsx
+++ b/src/app/(pages)/auth/sign-up/_components/SignUp.tsx
@@ -11,6 +11,7 @@ import { api } from '@/lib/axios/axios';
 import { CustomSession, JaksimOAuthProviderType } from '@/lib/next-auth/auth';
 import SignUpAgree from './SignUpAgree';
 
+
 export interface UserSignUpDto {
   AT: string | null;
   RT: string | null;
@@ -51,7 +52,7 @@ export default function SignUp() {
       social: sessionWithAccount.account.provider.toUpperCase(),
       userUniqueId: sessionWithAccount.account.providerAccountId,
     };
-    const response = (await api.post('/auth/sign-up', user)) as {
+    const response = (await api.post('/sign-up', user)) as {
       data: { data: UserSignUpDto };
     };
     const { AT, RT } = response.data.data;
@@ -73,7 +74,7 @@ export default function SignUp() {
       if (username?.length < 2) return;
 
       try {
-        // await api.post('/auth/sign-up/nick-check', { nickname: username });
+        await api.post('/sign-up/nick-check', { nickname: username });
         return true;
       } catch (error) {
         if (error instanceof Error) {

--- a/src/app/(pages)/challenge/[challengeId]/_components/ChallengeContents.tsx
+++ b/src/app/(pages)/challenge/[challengeId]/_components/ChallengeContents.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { Mission, Reward } from '@/types/challenge';
+import MissionItem from '../../_components/MissionItem';
+import RewardItem from '../../_components/RewardItem';
+import { type TabType } from '../page';
+import NewMission from './NewMission';
+import NewReward from './NewReward';
+
+export default function ChallengeContents({
+  challengeId,
+  tab,
+  rewards,
+  missions,
+}: {
+  challengeId: string;
+  tab: TabType;
+  rewards: Reward[];
+  missions: Mission[];
+}) {
+  return (
+    <>
+      {tab === 'mission-ongoing' && (
+        <ListWrapper>
+          {missions.map((mission) => (
+            <MissionItem key={mission.id} mission={mission} hasFavorite={true} />
+          ))}
+          <NewMission challengeId={challengeId} />
+        </ListWrapper>
+      )}
+      {tab === 'reward-page' && (
+        <ListWrapper>
+          {rewards.map((reward) => (
+            <RewardItem key={reward.id} reward={reward} hasFavorite={true} />
+          ))}
+          <NewReward challengeId={challengeId} />
+        </ListWrapper>
+      )}
+      {tab === 'mission-complete' && (
+        <ListWrapper>
+          {missions.map((mission) => (
+            <MissionItem key={mission.id} mission={mission} hasFavorite={true} isFinished={true} />
+          ))}
+        </ListWrapper>
+      )}
+    </>
+  );
+}
+
+const ListWrapper = ({ children }: { children: React.ReactNode }) => {
+  return <ul className='flex flex-col gap-4 pt-4'>{children}</ul>;
+};

--- a/src/app/(pages)/challenge/[challengeId]/_components/NewChallengeItemModal.tsx
+++ b/src/app/(pages)/challenge/[challengeId]/_components/NewChallengeItemModal.tsx
@@ -8,6 +8,7 @@ import Modal from '@/components/modal/Modal';
 import Portal from '@/components/modal/ModalPortal';
 import { useModal } from '@/hooks/useModal';
 
+
 interface MissionType {
   tag: 'mission';
   data: {
@@ -40,7 +41,7 @@ export default function ContinueConfirmModal({
     return () => {
       modalProps.closeModal();
     };
-  }, [savedData]);
+  }, [savedData, modalProps]);
 
   if (!savedData) return null;
 

--- a/src/app/(pages)/challenge/[challengeId]/_components/UserChallengeCard.tsx
+++ b/src/app/(pages)/challenge/[challengeId]/_components/UserChallengeCard.tsx
@@ -1,8 +1,10 @@
+'use client';
+
 import { Coins } from '@/assets/images/icons';
-import { type Challenge } from '../../_components/ChallengeList';
+import { type ChallengeType } from '@/models/challenge/Challenge';
 import Progress from './Progress';
 
-export default function UserChallengeCard({ challenge }: { challenge: Challenge }) {
+export default function UserChallengeCard({ challenge }: { challenge: ChallengeType }) {
   const userName = '홍길동';
   // TODO: 챌린지 참여시작 날짜 필요
   const challengeDay = new Date(challenge.createdAt).getDate();
@@ -10,9 +12,8 @@ export default function UserChallengeCard({ challenge }: { challenge: Challenge 
   // TODO: 주간 참여도 계산 필요
   const progress = 80;
 
-
   return (
-    <div className='bg-v1-text-primary-75 flex h-[11.25rem] flex-col justify-between gap-2 rounded-2xl px-6 py-6'>
+    <div className='flex h-[11.25rem] flex-col justify-between gap-2 rounded-2xl bg-v1-text-primary-75 px-6 py-6'>
       <div className='flex'>
         <div className='flex-1'>
           <p className='text-lg'>

--- a/src/app/(pages)/challenge/[challengeId]/detail/page.tsx
+++ b/src/app/(pages)/challenge/[challengeId]/detail/page.tsx
@@ -1,17 +1,16 @@
 import Button from '@/components/button/Button';
 import Header from '@/components/layout/Header';
 import PageLayout from '@/components/layout/PageLayout';
+import { Challenge } from '@/models/challenge/Challenge';
 import ChallengeDetail from '../../_components/ChallengeDetail';
-import { DummyChallenge } from '../../_components/ChallengeList';
 import ChallengeModal from './_components/ChallengeModal';
 
 const Page = async ({ params }: { params: { challengeId: string } }) => {
   const challengeId = params.challengeId;
-  const challenge = DummyChallenge;
-  const isJoined = false;
+  const challenge = await Challenge.getChallenge(parseInt(challengeId));
 
-  // TODO:
-  console.log('fetch challenge data with id: ' + challengeId);
+  // TODO: 챌린지 가입 여부 확인
+  const isJoined = false;
 
   return (
     <PageLayout
@@ -19,7 +18,7 @@ const Page = async ({ params }: { params: { challengeId: string } }) => {
         <Header className='border-none bg-v1-background'>
           <Header.BackButton tail={true} />
           <Header.Center>챌린지 정보</Header.Center>
-          <ChallengeModal />
+          {isJoined && <ChallengeModal />}
         </Header>
       }
       className='bg-v1-background'

--- a/src/app/(pages)/challenge/[challengeId]/page.tsx
+++ b/src/app/(pages)/challenge/[challengeId]/page.tsx
@@ -1,18 +1,12 @@
-'use client';
-
-import { useSession } from 'next-auth/react';
 import Link from 'next/link';
 import { Hamburger, Speaker } from '@/assets/images/icons';
 import Header from '@/components/layout/Header';
 import PageLayout from '@/components/layout/PageLayout';
 import LinkTabs from '@/components/tab/LinkTabs';
-import { DummyChallenge } from '../_components/ChallengeList';
-import MissionItem from '../_components/MissionItem';
-import RewardItem from '../_components/RewardItem';
+import { Challenge } from '@/models/challenge/Challenge';
 import dummyMission from '../_mock/dummyMission.json';
 import dummyReward from '../_mock/dummyReward.json';
-import NewMission from './_components/NewMission';
-import NewReward from './_components/NewReward';
+import ChallengeContents from './_components/ChallengeContents';
 import UserChallengeCard from './_components/UserChallengeCard';
 
 const TABS = [
@@ -20,8 +14,9 @@ const TABS = [
   { type: 'reward-page', label: '보상 페이지', href: '?tab=reward-page' },
   { type: 'mission-complete', label: '미션 완료', href: '?tab=mission-complete' },
 ];
+export type TabType = (typeof TABS)[number]['type'];
 
-export default function Page({
+export default async function Page({
   params,
   searchParams,
 }: {
@@ -29,22 +24,18 @@ export default function Page({
   searchParams: { tab: string };
 }) {
   const challengeId = params.challengeId;
-  const challenge = DummyChallenge;
-  const session = useSession();
 
-  // TODO:
-  console.log('fetch challenge data with id: ' + challengeId);
-  console.log('user have to join challenge: ', session.data?.user);
-
+  const challenge = await Challenge.getChallenge(parseInt(challengeId));
   const rewards = dummyReward;
   const missions = dummyMission;
+  const tab = searchParams.tab || 'mission-ongoing';
 
   return (
     <PageLayout
       header={
         <Header className='border-none bg-v1-background'>
           <Header.BackButton tail={true} />
-          <Header.Center>{challenge.name}</Header.Center>
+          <Header.Center>{challenge?.name}</Header.Center>
           <div className='flex gap-3'>
             <Link href={`/chat/${challengeId}`}>
               <Speaker />
@@ -58,35 +49,8 @@ export default function Page({
       className='bg-v1-background px-6 pt-2'
     >
       <UserChallengeCard challenge={challenge} />
-      <LinkTabs tab={searchParams.tab} tabs={TABS} />
-
-      {searchParams.tab === 'reward-page' && (
-        <ListWrapper>
-          {rewards.map((reward) => (
-            <RewardItem key={reward.id} reward={reward} hasFavorite={true} />
-          ))}
-          <NewReward challengeId={challengeId} />
-        </ListWrapper>
-      )}
-      {searchParams.tab === 'mission-ongoing' && (
-        <ListWrapper>
-          {missions.map((mission) => (
-            <MissionItem key={mission.id} mission={mission} hasFavorite={true} />
-          ))}
-          <NewMission challengeId={challengeId} />
-        </ListWrapper>
-      )}
-      {searchParams.tab === 'mission-complete' && (
-        <ListWrapper>
-          {missions.map((mission) => (
-            <MissionItem key={mission.id} mission={mission} hasFavorite={true} isFinished={true} />
-          ))}
-        </ListWrapper>
-      )}
+      <LinkTabs tab={tab} tabs={TABS} />
+      <ChallengeContents challengeId={challengeId} tab={tab} rewards={rewards} missions={missions} />
     </PageLayout>
   );
 }
-
-const ListWrapper = ({ children }: { children: React.ReactNode }) => {
-  return <ul className='flex flex-col gap-4 pt-4'>{children}</ul>;
-};

--- a/src/app/(pages)/challenge/_components/ChallengeCard.tsx
+++ b/src/app/(pages)/challenge/_components/ChallengeCard.tsx
@@ -1,9 +1,10 @@
+import { useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { ArrowRight, CrownFill, Fire, Lightning } from '@/assets/images/icons';
 import challengeImage from '@/assets/images/placeholder/chat-list.png';
 import { cn } from '@/lib/shadcn/utils';
-import { Challenge } from './ChallengeList';
+import { type ChallengeType } from '@/models/challenge/Challenge';
 
 const INDEX_COLOR = [
   { text: 'text-v1-orange-500', bg: 'bg-v1-orange-500' },
@@ -11,21 +12,39 @@ const INDEX_COLOR = [
   { text: 'text-[#F56060]', bg: 'bg-[#F56060]' },
 ];
 
-export default function ChallengeCard({ challenge, userId }: { challenge: Challenge; userId: string }) {
-  const { name, backgroundImage, tags, challengeId, currentParticipants, creatorUserUuid } = challenge;
+export default function ChallengeCard({ challenge, userId }: { challenge: ChallengeType; userId: string }) {
+  const { name, backgroundImage, challengeId, currentParticipants, creatorUserUuid } = challenge;
   const color = INDEX_COLOR[challengeId % INDEX_COLOR.length];
-  const mission = tags;
   const isOwner = creatorUserUuid === userId;
+  const [isImageError, setIsImageError] = useState(false);
+
+  const handleImageError = () => {
+    setIsImageError(true);
+  };
 
   // TODO: API 연동 필요한 값: point
+  const mission = [''];
   const point = 1000;
 
   return (
-    <div className='relative min-h-[180px] rounded-2xl bg-white'>
+    <div className='relative min-h-[180px] rounded-2xl'>
       {isOwner && <CrownFill className='absolute -top-3 right-8 z-10' />}
 
       <div className='absolute bottom-0 left-0 right-0 top-0 overflow-hidden rounded-2xl'>
-        <Image src={backgroundImage || challengeImage} alt='챌린지 이미지' fill className='object-cover' />
+        {backgroundImage && !isImageError ? (
+          <>
+            <Image
+              src={backgroundImage || challengeImage}
+              alt='챌린지 이미지'
+              fill
+              className='object-cover'
+              onError={handleImageError}
+            />
+            <div className='absolute bottom-0 left-0 right-0 top-0 bg-black/50' />
+          </>
+        ) : (
+          <div className='absolute bottom-0 left-0 right-0 top-0 bg-gradient-to-r from-black to-black/30' />
+        )}
       </div>
 
       <div className='absolute bottom-0 left-0 right-0 top-0 p-5 text-white'>

--- a/src/app/(pages)/challenge/_components/ChallengeDetail.tsx
+++ b/src/app/(pages)/challenge/_components/ChallengeDetail.tsx
@@ -5,15 +5,17 @@ import { differenceInDays } from 'date-fns';
 import { Fire, Gem, Lightning } from '@/assets/images/icons';
 import Accodion from '@/components/accodion/Accodion';
 import Chip from '@/components/chip/Chip';
+import { type ChallengeType } from '@/models/challenge/Challenge';
 import dummyMission from '../_mock/dummyMission.json';
 import dummyReward from '../_mock/dummyReward.json';
-import { Challenge } from './ChallengeList';
 import MissionList from './MissionList';
 import ParticipantList from './ParticipantList';
 import RewardList from './RewardList';
 
-export default function ChallengeDetail({ challenge }: { challenge: Challenge }) {
+export default function ChallengeDetail({ challenge }: { challenge: ChallengeType }) {
   const currentChallengeStreak = differenceInDays(new Date(), new Date(challenge.createdAt)).toString();
+
+  // TODO: API 연동 필요한 값: rewards, missions
   const rewards = dummyReward;
   const missions = dummyMission;
 
@@ -28,10 +30,11 @@ export default function ChallengeDetail({ challenge }: { challenge: Challenge })
               fill
               sizes='300px'
               className='rounded-t-xl object-cover'
+              priority
             />
           )}
           <div className='absolute right-3 top-3 rounded-xl bg-white px-[6px] py-[1px] text-xs text-v1-text-primary-400'>
-            {challenge.isPublic ? '공개' : '비공개'}
+            {challenge.public ? '공개' : '비공개'}
           </div>
         </div>
         <div className='flex flex-col gap-5 px-4 py-6 text-center'>

--- a/src/app/(pages)/challenge/_components/ChallengeList.tsx
+++ b/src/app/(pages)/challenge/_components/ChallengeList.tsx
@@ -3,47 +3,16 @@
 import Image from 'next/image';
 import EmptyChallengeImg from '@/assets/images/placeholder/face-sad.png';
 import { CustomSession } from '@/lib/next-auth/auth';
+import { type ChallengeListType } from '@/models/challenge/Challenge';
 import ChallengeCard from './ChallengeCard';
 
-export interface Challenge {
-  challengeId: number;
-  name: string;
-  backgroundImage: string;
-  isPublic: boolean;
-  currentParticipants: number;
-  maxParticipant: number;
-  minParticipant: number;
-  tags: string[];
-  createdAt: string;
-  updatedAt: string;
-  creatorUserUuid: string;
-}
-
-export const DummyChallenge: Challenge = {
-  challengeId: 999,
-  name: '챌린지 이름입니다',
-  backgroundImage: '',
-  isPublic: true,
-  currentParticipants: 3,
-  maxParticipant: 10,
-  minParticipant: 3,
-  tags: ['영어', '수학', '교과서위주'],
-  createdAt: '2024-11-25T10:19:30',
-  updatedAt: '2024-11-25T10:19:30',
-  creatorUserUuid: 'useruuid',
-};
-
-function getDummyChallengeList(): Challenge[] {
-  return new Array(5).fill(null).map((_, index) => ({
-    ...DummyChallenge,
-    challengeId: index,
-    currentParticipants: index % 2 === 0 ? 3 : 10,
-  }));
-}
-
-export default function ChallengeList({ session }: { session: CustomSession }) {
-  const challengeList = getDummyChallengeList();
-
+export default function ChallengeList({
+  session,
+  challengeList,
+}: {
+  session: CustomSession;
+  challengeList: ChallengeListType;
+}) {
   if (challengeList.length === 0) {
     return <EmptyChallengeList />;
   }

--- a/src/app/(pages)/challenge/code/_components/CodeForm.tsx
+++ b/src/app/(pages)/challenge/code/_components/CodeForm.tsx
@@ -6,13 +6,13 @@ import { FieldValues, useForm } from 'react-hook-form';
 import { Search } from '@/assets/images/icons';
 import Button from '@/components/button/Button';
 import InputWithError from '@/components/input/InputWithErrorMsg';
+import { Challenge, type ChallengeType } from '@/models/challenge/Challenge';
 import ChallengeCard from '../../_components/ChallengeCard';
-import { Challenge, DummyChallenge } from '../../_components/ChallengeList';
 
 
 export default function CodeForm({ userId }: { userId: string }) {
   const router = useRouter();
-  const [challenge, setChallenge] = useState<Challenge | null>(null);
+  const [challenge, setChallenge] = useState<ChallengeType | null>(null);
   const codeLength = 6;
 
   const {
@@ -35,11 +35,12 @@ export default function CodeForm({ userId }: { userId: string }) {
       if (!code) return;
 
       try {
-        // const response = await api.get(`/challenge/find/${code}`);
+        // const response = await challengeApi.findChallengeByCode(code);
         const response = code === '123456';
+        const challenge = await Challenge.getChallenge(1);
 
         if (response) {
-          setChallenge(DummyChallenge);
+          setChallenge(challenge);
         } else {
           setChallenge(null);
           setError('code', { message: '해당 코드로는 챌린지가 확인되지 않아요' });

--- a/src/app/(pages)/challenge/create/_components/CreateChallengeForm.tsx
+++ b/src/app/(pages)/challenge/create/_components/CreateChallengeForm.tsx
@@ -7,19 +7,10 @@ import { z } from 'zod';
 import Button from '@/components/button/Button';
 import InputUnderline from '@/components/input/InputUnderline';
 import { Switch } from '@/components/ui/switch';
-import { api } from '@/lib/axios/axios';
+import { Challenge, ChallengeCreateDTO } from '@/models/challenge/Challenge';
 import HashTags from './HashTags';
 import TwoWaySlider from './TwoWaySlider';
 import UploadThumbnail from './UploadThumbnail';
-
-export interface Challenge {
-  challengeName: string;
-  backgroundImage: string;
-  isPublic: boolean;
-  minParticipants: number;
-  maxParticipants: number;
-  tags: string[];
-}
 
 const schema = z.object({
   challengeName: z.string().min(1).max(20),
@@ -39,10 +30,10 @@ export default function CreateChallengeForm() {
     setValue,
     getValues,
     formState: { errors },
-  } = useForm<Challenge>({
+  } = useForm<ChallengeCreateDTO>({
     resolver: zodResolver(schema),
     defaultValues: {
-      challengeName: '',
+      name: '',
       backgroundImage: '',
       isPublic: false,
       minParticipants: 3,
@@ -51,7 +42,7 @@ export default function CreateChallengeForm() {
     },
   });
 
-  const challengeName = useWatch({ control, name: 'challengeName' });
+  const challengeName = useWatch({ control, name: 'name' });
   const minParticipants = useWatch({ control, name: 'minParticipants' });
   const maxParticipants = useWatch({ control, name: 'maxParticipants' });
   const backgroundImage = useWatch({ control, name: 'backgroundImage' });
@@ -61,15 +52,10 @@ export default function CreateChallengeForm() {
     if (getValues('maxParticipants') !== value[1]) setValue('maxParticipants', value[1]);
   };
 
-  const onSubmit = async (data: Challenge) => {
-    const { challengeName, ...rest } = data;
-    const newData = {
-      name: challengeName,
-      ...rest,
-    };
+  const onSubmit = async (data: ChallengeCreateDTO) => {
     try {
-      const response = await api.post('/challenge/create', newData);
-      const challengeId = response.data.challengeId;
+      const response = await Challenge.createChallenge(data);
+      const challengeId = response.challengeId;
       router.push(`/challenge/create/success?challengeId=${challengeId}`);
     } catch (error) {
       console.error(error);
@@ -87,8 +73,8 @@ export default function CreateChallengeForm() {
             hasMaxLength={true}
             maxLength={20}
             currentLength={challengeName.length}
-            isError={!!errors.challengeName}
-            {...register('challengeName')}
+            isError={!!errors.name}
+            {...register('name')}
           />
 
           <Controller

--- a/src/app/(pages)/challenge/page.tsx
+++ b/src/app/(pages)/challenge/page.tsx
@@ -2,17 +2,20 @@ import { getServerSession } from 'next-auth';
 import Header from '@/components/layout/Header';
 import PageLayout from '@/components/layout/PageLayout';
 import { CustomSession } from '@/lib/next-auth/auth';
+import { Challenge } from '@/models/challenge/Challenge';
 import BottomNav from './_components/BottomNav';
 import ChallengeList from './_components/ChallengeList';
 
-
-const Page = async () => {
+const Page = async ({ searchParams }: { searchParams: { page: string } }) => {
   const session = await getServerSession();
 
   if (!session) {
     // TODO: 로그인 페이지로 리다이렉트
   }
+
   const notNullSession = session as CustomSession;
+  const page = searchParams.page ? parseInt(searchParams.page) : 1;
+  const challengeList = await Challenge.getChallengeList(page);
 
   return (
     <PageLayout
@@ -27,7 +30,7 @@ const Page = async () => {
       <div className='flex h-full flex-col'>
         <div className='my-2 text-center text-xs text-v1-text-primary-400'>진행 중인 챌린지</div>
         <div className='flex-1 px-6'>
-          <ChallengeList session={notNullSession} />
+          <ChallengeList session={notNullSession} challengeList={challengeList} />
         </div>
         <BottomNav />
       </div>

--- a/src/components/tab/LinkTabs.tsx
+++ b/src/components/tab/LinkTabs.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Link from 'next/link';
 
 type LinkTab<T> = T extends Array<{ type: string; label: string; href: string }> ? T[number] : never;
@@ -10,7 +12,7 @@ function LinkTabs<T extends Array<{ type: string; label: string; href: string }>
   tabs: T;
 }) {
   return (
-    <ul className='border-v1-text-primary-75 -mx-6 mt-4 flex h-12 justify-between border-b'>
+    <ul className='-mx-6 mt-4 flex h-12 justify-between border-b border-v1-text-primary-75'>
       {tabs.map((e) => (
         <TabLinkButton key={e.type} tab={e} currentTabType={tab} />
       ))}

--- a/src/models/challenge/Challenge.ts
+++ b/src/models/challenge/Challenge.ts
@@ -1,0 +1,46 @@
+import { api } from '@/lib/axios/axios';
+
+export interface ChallengeCreateDTO {
+  name: string;
+  backgroundImage: string | null;
+  isPublic: boolean;
+  minParticipants: number;
+  maxParticipants: number;
+  tags: string[];
+}
+
+export interface ChallengeType {
+  challengeId: number;
+  name: string;
+  backgroundImage: string;
+  public: boolean;
+  currentParticipants: number;
+  maxParticipants: number;
+  tags: string[];
+  createdAt: string;
+  creatorUserUuid: string;
+  participants: string[] | null;
+}
+export type ChallengeListType = ChallengeType[];
+
+class ChallengeClass {
+  getChallengeList = async (page: number) => {
+    const response = await api.get(`http://localhost:3001/challenge?page=${page}`);
+    return response.data as ChallengeType[];
+  };
+  getChallenge = async (challengeId: number) => {
+    const response = await api.get(`http://localhost:3001/challenge/${challengeId}`);
+    return response.data as ChallengeType;
+  };
+  findChallengeByCode = async (code: string) => {
+    const response = await api.get(`http://localhost:3001/challenge/find/${code}`);
+    return response.data as ChallengeType;
+  };
+  createChallenge = async (challenge: ChallengeCreateDTO) => {
+    const response = await api.post('/challenge/create', challenge);
+    return response.data as ChallengeType;
+  };
+}
+
+const Challenge = new ChallengeClass();
+export { Challenge };


### PR DESCRIPTION
## Challenge api 관련 작업
2024년 12월 21일 기준, 라이브 api 체크사항

## 작업 내용

### Challenge mock 데이터 형태 변경
- api 명세서 기반 => 실제 서버의 응답 예시데이터
- json-server 추가(의견 받아여!)
```js
// 3001포트로 json server 시작
yarn start:mock 
```

### Challenge model 파일 추가
- /challenge* api 요청 이동
- 관련 타입 이동

### 잘못된 api요청 수정
- /auth/user*=> /user*

### 그 외
- page를 async 서버 컴포넌트로 변경하기 위해서, 하위 client 컴포넌트 분리
- mock 데이터 image 도메인을 next.config.mjs에 추가
- 챌린지 카드 UI에서 빠트린 사항 추가