### PR TITLE
feat: 임시저장 기능 구현

### DIFF
--- a/src/app/(pages)/_components/ModalProvider.tsx
+++ b/src/app/(pages)/_components/ModalProvider.tsx
@@ -8,7 +8,8 @@ export type ModalNames =
   | 'cancel-create-challenge'
   | 'challenge-modal'
   | 'withdraw-modal'
-  | 'new-challenge-item';
+  | 'new-mission'
+  | 'new-reward';
 
 export interface ModalContextProps {
   modalState: ModalNames[];

--- a/src/app/(pages)/challenge/[challengeId]/_components/NewChallengeItemModal.tsx
+++ b/src/app/(pages)/challenge/[challengeId]/_components/NewChallengeItemModal.tsx
@@ -1,58 +1,23 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
 import { motion } from 'framer-motion';
 import { X } from '@/assets/images/icons';
 import Button from '@/components/button/Button';
 import Modal from '@/components/modal/Modal';
 import Portal from '@/components/modal/ModalPortal';
-import { useModal } from '@/hooks/useModal';
+import { ModalProps } from '@/hooks/useModal';
 
-
-interface MissionType {
-  tag: 'mission';
-  data: {
-    name: string;
-  };
-}
-
-interface RewardType {
-  tag: 'reward';
-  data: {
-    name: string;
-  };
-}
-export type LocalSavedChallengeItem = MissionType | RewardType;
-
-export default function ContinueConfirmModal({
-  savedData,
-  onSaveLoad: onOk,
-}: {
-  savedData: LocalSavedChallengeItem | null;
+interface ContinueConfirmModalProps {
+  type: 'mission' | 'reward';
+  savedData: { name: string };
   onSaveLoad: () => void;
-}) {
-  const modalProps = useModal('new-challenge-item');
+  onNewMission: () => void;
+  modalProps: ModalProps;
+}
+
+export default function ContinueConfirmModal({ type, savedData, onSaveLoad, onNewMission, modalProps }: ContinueConfirmModalProps) {
   const modalRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (savedData) {
-      modalProps.openModal();
-    }
-    return () => {
-      modalProps.closeModal();
-    };
-  }, [savedData, modalProps]);
-
-  if (!savedData) return null;
-
-  const onContinueButtonClick = () => {
-    onOk();
-    modalProps.closeModal();
-  };
-
-  const onNewButtonClick = () => {
-    modalProps.closeModal();
-  };
 
   return (
     <Portal>
@@ -69,23 +34,18 @@ export default function ContinueConfirmModal({
               <X className='absolute right-5 top-5 scale-75 cursor-pointer' onPointerDown={modalProps.closeModal} />
               <div className='mb-4 mt-4 flex flex-col gap-2'>
                 <div className='text-2xl font-medium text-v1-text-primary-700'>
-                  작성 중인 {savedData.tag === 'mission' ? '미션이' : '리워드가'} 있어요
+                  작성 중인 {type === 'mission' ? '미션이' : '리워드가'} 있어요
                 </div>
                 <div className='text-base text-v1-text-primary-500'>
-                  ‘{savedData.data.name}’ {savedData.tag === 'mission' ? '도전' : ''}을 이어서 작성할까요?
+                  ‘{savedData.name}’ {type === 'mission' ? '도전' : ''}을 이어서 작성할까요?
                 </div>
               </div>
               <div className='mb-2 flex flex-col gap-2 font-semibold text-v1-text-primary-700'>
-                <Button
-                  onClick={onContinueButtonClick}
-                  type='button'
-                  size='md'
-                  variant={savedData.tag === 'mission' ? 'primary' : 'blue'}
-                >
+                <Button onClick={onSaveLoad} type='button' size='md' variant={type === 'mission' ? 'primary' : 'blue'}>
                   계속 작성하기
                 </Button>
-                <Button variant='outline' size='md' onClick={onNewButtonClick} type='button'>
-                  새 {savedData.tag === 'mission' ? '미션' : '리워드'} 작성하기
+                <Button variant='outline' size='md' onClick={onNewMission} type='button'>
+                  새 {type === 'mission' ? '미션' : '리워드'} 작성하기
                 </Button>
               </div>
             </div>

--- a/src/app/(pages)/challenge/[challengeId]/_components/NewChallengeItemModal.tsx
+++ b/src/app/(pages)/challenge/[challengeId]/_components/NewChallengeItemModal.tsx
@@ -12,11 +12,17 @@ interface ContinueConfirmModalProps {
   type: 'mission' | 'reward';
   savedData: { name: string };
   onSaveLoad: () => void;
-  onNewMission: () => void;
+  onStartNew: () => void;
   modalProps: ModalProps;
 }
 
-export default function ContinueConfirmModal({ type, savedData, onSaveLoad, onNewMission, modalProps }: ContinueConfirmModalProps) {
+export default function ContinueConfirmModal({
+  type,
+  savedData,
+  onSaveLoad,
+  onStartNew,
+  modalProps,
+}: ContinueConfirmModalProps) {
   const modalRef = useRef<HTMLDivElement>(null);
 
   return (
@@ -44,7 +50,7 @@ export default function ContinueConfirmModal({ type, savedData, onSaveLoad, onNe
                 <Button onClick={onSaveLoad} type='button' size='md' variant={type === 'mission' ? 'primary' : 'blue'}>
                   계속 작성하기
                 </Button>
-                <Button variant='outline' size='md' onClick={onNewMission} type='button'>
+                <Button variant='outline' size='md' onClick={onStartNew} type='button'>
                   새 {type === 'mission' ? '미션' : '리워드'} 작성하기
                 </Button>
               </div>

--- a/src/app/(pages)/challenge/[challengeId]/_components/NewMission.tsx
+++ b/src/app/(pages)/challenge/[challengeId]/_components/NewMission.tsx
@@ -7,26 +7,27 @@ import ContinueConfirmModal from './NewChallengeItemModal';
 
 export default function NewMission({ challengeId }: { challengeId: string }) {
   const router = useRouter();
-  const [localSavedMission] = useLocalStorage('mission-create') as unknown as [{ name: string } | null];
+  const [localSavedMission, , removeSavedMission] = useLocalStorage('mission-create') as unknown as [
+    { name: string } | null,
+    (value: { name: string } | null) => void,
+    () => void,
+  ];
   const modalProps = useModal('new-mission');
-
-  const MISSION_CREATE_PAGE = `/challenge/${challengeId}/mission/create`;
-  const TEMP_MISSION_CREATE_PAGE = `/challenge/${challengeId}/mission/create?temp=true`;
+  const goToCreateMission = () => {
+    router.push(`/challenge/${challengeId}/mission/create`);
+  };
 
   const onAddItemClick = () => {
     if (localSavedMission) {
       modalProps.openModal();
     } else {
-      router.push(MISSION_CREATE_PAGE);
+      goToCreateMission();
     }
   };
 
-  const onNewMission = () => {
-    router.push(MISSION_CREATE_PAGE);
-  };
-
-  const onSaveLoad = () => {
-    router.push(TEMP_MISSION_CREATE_PAGE);
+  const onStartNew = () => {
+    removeSavedMission();
+    goToCreateMission();
   };
 
   return (
@@ -35,8 +36,8 @@ export default function NewMission({ challengeId }: { challengeId: string }) {
         <ContinueConfirmModal
           type='mission'
           savedData={localSavedMission}
-          onSaveLoad={onSaveLoad}
-          onNewMission={onNewMission}
+          onSaveLoad={goToCreateMission}
+          onStartNew={onStartNew}
           modalProps={modalProps}
         />
       )}

--- a/src/app/(pages)/challenge/[challengeId]/_components/NewMission.tsx
+++ b/src/app/(pages)/challenge/[challengeId]/_components/NewMission.tsx
@@ -1,31 +1,46 @@
-import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { useLocalStorage } from 'react-use';
+import { useModal } from '@/hooks/useModal';
 import AddItemButton from './AddItemButton';
-import ContinueConfirmModal, { type LocalSavedChallengeItem } from './NewChallengeItemModal';
+import ContinueConfirmModal from './NewChallengeItemModal';
+
 
 export default function NewMission({ challengeId }: { challengeId: string }) {
   const router = useRouter();
-  const [savedData, setSavedData] = useState<LocalSavedChallengeItem | null>(null);
+  const [localSavedMission] = useLocalStorage('mission-create') as unknown as [{ name: string } | null];
+  const modalProps = useModal('new-mission');
 
-  const newMission = () => {
-    const localSavedMission = localStorage.getItem('saved-mission');
+  const MISSION_CREATE_PAGE = `/challenge/${challengeId}/mission/create`;
+  const TEMP_MISSION_CREATE_PAGE = `/challenge/${challengeId}/mission/create?temp=true`;
 
+  const onAddItemClick = () => {
     if (localSavedMission) {
-      const parsedMission = JSON.parse(localSavedMission);
-      setSavedData({ tag: 'mission', data: parsedMission });
+      modalProps.openModal();
     } else {
-      router.push(`/challenge/${challengeId}/mission/create`);
+      router.push(MISSION_CREATE_PAGE);
     }
   };
 
+  const onNewMission = () => {
+    router.push(MISSION_CREATE_PAGE);
+  };
+
   const onSaveLoad = () => {
-    router.push(`/challenge/${challengeId}/mission/create?continue=true`);
+    router.push(TEMP_MISSION_CREATE_PAGE);
   };
 
   return (
     <>
-      <ContinueConfirmModal savedData={savedData} onSaveLoad={onSaveLoad} />
-      <AddItemButton color='orange' onClick={newMission} />
+      {localSavedMission && (
+        <ContinueConfirmModal
+          type='mission'
+          savedData={localSavedMission}
+          onSaveLoad={onSaveLoad}
+          onNewMission={onNewMission}
+          modalProps={modalProps}
+        />
+      )}
+      <AddItemButton color='orange' onClick={onAddItemClick} />
     </>
   );
 }

--- a/src/app/(pages)/challenge/[challengeId]/_components/NewReward.tsx
+++ b/src/app/(pages)/challenge/[challengeId]/_components/NewReward.tsx
@@ -4,28 +4,30 @@ import { useModal } from '@/hooks/useModal';
 import AddItemButton from './AddItemButton';
 import ContinueConfirmModal from './NewChallengeItemModal';
 
+
 export default function NewReward({ challengeId }: { challengeId: string }) {
   const router = useRouter();
-  const [localSavedReward] = useLocalStorage('saved-reward') as unknown as [{ name: string } | null];
+  const [localSavedReward, , removeSavedReward] = useLocalStorage('reward-create') as unknown as [
+    { name: string } | null,
+    (value: { name: string } | null) => void,
+    () => void,
+  ];
   const modalProps = useModal('new-reward');
+  const goToCreateReward = () => {
+    router.push(`/challenge/${challengeId}/reward/create`);
+  };
 
-  const REWARD_CREATE_PAGE = `/challenge/${challengeId}/reward/create`;
-  const TEMP_REWARD_CREATE_PAGE = `/challenge/${challengeId}/reward/create?temp=true`;
-
-  const newReward = () => {
+  const onAddItemClick = () => {
     if (localSavedReward) {
       modalProps.openModal();
     } else {
-      router.push(REWARD_CREATE_PAGE);
+      goToCreateReward();
     }
   };
 
-  const onNewReward = () => {
-    router.push(REWARD_CREATE_PAGE);
-  };
-
-  const onSaveLoad = () => {
-    router.push(TEMP_REWARD_CREATE_PAGE);
+  const onStartNew = () => {
+    removeSavedReward();
+    goToCreateReward();
   };
 
   return (
@@ -34,12 +36,12 @@ export default function NewReward({ challengeId }: { challengeId: string }) {
         <ContinueConfirmModal
           type='reward'
           savedData={localSavedReward}
-          onSaveLoad={onSaveLoad}
-          onNewMission={onNewReward}
+          onSaveLoad={goToCreateReward}
+          onStartNew={onStartNew}
           modalProps={modalProps}
         />
       )}
-      <AddItemButton color='blue' onClick={newReward} />
+      <AddItemButton color='blue' onClick={onAddItemClick} />
     </>
   );
 }

--- a/src/app/(pages)/challenge/[challengeId]/_components/NewReward.tsx
+++ b/src/app/(pages)/challenge/[challengeId]/_components/NewReward.tsx
@@ -1,30 +1,44 @@
-import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { useLocalStorage } from 'react-use';
+import { useModal } from '@/hooks/useModal';
 import AddItemButton from './AddItemButton';
-import ContinueConfirmModal, { type LocalSavedChallengeItem } from './NewChallengeItemModal';
+import ContinueConfirmModal from './NewChallengeItemModal';
 
 export default function NewReward({ challengeId }: { challengeId: string }) {
   const router = useRouter();
-  const [savedData, setSavedData] = useState<LocalSavedChallengeItem | null>(null);
+  const [localSavedReward] = useLocalStorage('saved-reward') as unknown as [{ name: string } | null];
+  const modalProps = useModal('new-reward');
+
+  const REWARD_CREATE_PAGE = `/challenge/${challengeId}/reward/create`;
+  const TEMP_REWARD_CREATE_PAGE = `/challenge/${challengeId}/reward/create?temp=true`;
 
   const newReward = () => {
-    const localSavedReward = localStorage.getItem('saved-reward');
-
     if (localSavedReward) {
-      const parsedReward = JSON.parse(localSavedReward);
-      setSavedData({ tag: 'reward', data: parsedReward });
+      modalProps.openModal();
     } else {
-      router.push(`/challenge/${challengeId}/reward/create`);
+      router.push(REWARD_CREATE_PAGE);
     }
   };
 
+  const onNewReward = () => {
+    router.push(REWARD_CREATE_PAGE);
+  };
+
   const onSaveLoad = () => {
-    router.push(`/challenge/${challengeId}/reward/create?continue=true`);
+    router.push(TEMP_REWARD_CREATE_PAGE);
   };
 
   return (
     <>
-      <ContinueConfirmModal savedData={savedData} onSaveLoad={onSaveLoad} />
+      {localSavedReward && (
+        <ContinueConfirmModal
+          type='reward'
+          savedData={localSavedReward}
+          onSaveLoad={onSaveLoad}
+          onNewMission={onNewReward}
+          modalProps={modalProps}
+        />
+      )}
       <AddItemButton color='blue' onClick={newReward} />
     </>
   );

--- a/src/app/(pages)/challenge/[challengeId]/mission/create/DynamicPage.tsx
+++ b/src/app/(pages)/challenge/[challengeId]/mission/create/DynamicPage.tsx
@@ -7,12 +7,14 @@ import FunnelUi from '@/components/funnel/FunnelUi';
 import Header from '@/components/layout/Header';
 import PageLayout from '@/components/layout/PageLayout';
 import useTempSave from '@/hooks/useTempSave';
+import isVaildObject from '@/utils/isVaildObject';
 import { type FunnelProps } from './_components/ChallengeCreateFunnel/_context/context';
 import FunnelRender from './_components/ChallengeCreateFunnel/FunnelRender';
 
+
 export default function DynamicPageContent() {
   const router = useRouter();
-  const { saveTempData, autoSave, updateDraftTempData, draftTempData, tempData, clearTempData } =
+  const { saveTempData, autoSave, updateDraftTempData, draftTempData, savedTempData, clearTempData } =
     useTempSave<FunnelProps>({
       id: 'mission-create',
     });
@@ -20,19 +22,9 @@ export default function DynamicPageContent() {
     id: 'mission-create',
     initial: {
       step: 'missionDescription',
-      context: tempData as FunnelProps['missionDescription'],
+      context: savedTempData as FunnelProps['missionDescription'],
     },
   });
-
-  const isValidObject = (obj: Record<string, unknown> | null) => {
-    if (!obj) return false;
-    const conditions = [
-      typeof obj === 'object',
-      Object.keys(obj as object).length > 0,
-      Object.values(obj as object).some((value) => value),
-    ];
-    return conditions.every((condition) => condition);
-  };
 
   return (
     <PageLayout
@@ -56,7 +48,7 @@ export default function DynamicPageContent() {
             <FunnelUi.StepIndicator index={funnel.index} max={3} />
           </Header.Title>
           <Header.Item>
-            <Header.GrayText disabled={!isValidObject(draftTempData)}>
+            <Header.GrayText disabled={!isVaildObject(draftTempData)}>
               <button onClick={() => saveTempData(funnel.context)}>임시저장</button>
             </Header.GrayText>
           </Header.Item>

--- a/src/app/(pages)/challenge/[challengeId]/mission/create/DynamicPage.tsx
+++ b/src/app/(pages)/challenge/[challengeId]/mission/create/DynamicPage.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useFunnel } from '@use-funnel/browser';
+import { Chevron, X } from '@/assets/images/icons';
+import FunnelUi from '@/components/funnel/FunnelUi';
+import Header from '@/components/layout/Header';
+import PageLayout from '@/components/layout/PageLayout';
+import useTempSave from '@/hooks/useTempSave';
+import { type FunnelProps } from './_components/ChallengeCreateFunnel/_context/context';
+import FunnelRender from './_components/ChallengeCreateFunnel/FunnelRender';
+
+
+export default function DynamicPageContent({ searchParams }: { searchParams: { temp: string } }) {
+  const router = useRouter();
+  const { saveTempData, autoSave, updateDraftTempData, draftTempData, tempData, clearTempData } =
+    useTempSave<FunnelProps>({
+      id: 'mission-create',
+      useTempData: searchParams.temp === 'true',
+    });
+  const funnel = useFunnel<FunnelProps>({
+    id: 'mission-create',
+    initial: {
+      step: 'missionDescription',
+      context: tempData as FunnelProps['missionDescription'],
+    },
+  });
+
+  const isValidObject = (obj: Record<string, unknown> | null) => {
+    if (!obj) return false;
+    const conditions = [
+      typeof obj === 'object',
+      Object.keys(obj as object).length > 0,
+      Object.values(obj as object).some((value) => value),
+    ];
+    return conditions.every((condition) => condition);
+  };
+
+  return (
+    <PageLayout
+      className='px-6'
+      header={
+        <Header className='border-none bg-v1-background'>
+          <Header.Item>
+            {funnel.index > 0 ? (
+              <Header.Icon
+                Icon={Chevron}
+                onClick={() => {
+                  autoSave(funnel.context);
+                  funnel.history.back();
+                }}
+              />
+            ) : (
+              <Header.Icon Icon={X} onClick={() => router.back()} />
+            )}
+          </Header.Item>
+          <Header.Title>
+            <FunnelUi.StepIndicator index={funnel.index} max={3} />
+          </Header.Title>
+          <Header.Item>
+            <Header.GrayText disabled={!isValidObject(draftTempData)}>
+              <button onClick={() => saveTempData(funnel.context)}>임시저장</button>
+            </Header.GrayText>
+          </Header.Item>
+        </Header>
+      }
+    >
+      <FunnelRender
+        funnel={funnel}
+        updateDraftTempData={updateDraftTempData}
+        autoSave={autoSave}
+        clearTempData={clearTempData}
+      />
+    </PageLayout>
+  );
+}

--- a/src/app/(pages)/challenge/[challengeId]/mission/create/DynamicPage.tsx
+++ b/src/app/(pages)/challenge/[challengeId]/mission/create/DynamicPage.tsx
@@ -10,13 +10,11 @@ import useTempSave from '@/hooks/useTempSave';
 import { type FunnelProps } from './_components/ChallengeCreateFunnel/_context/context';
 import FunnelRender from './_components/ChallengeCreateFunnel/FunnelRender';
 
-
-export default function DynamicPageContent({ searchParams }: { searchParams: { temp: string } }) {
+export default function DynamicPageContent() {
   const router = useRouter();
   const { saveTempData, autoSave, updateDraftTempData, draftTempData, tempData, clearTempData } =
     useTempSave<FunnelProps>({
       id: 'mission-create',
-      useTempData: searchParams.temp === 'true',
     });
   const funnel = useFunnel<FunnelProps>({
     id: 'mission-create',

--- a/src/app/(pages)/challenge/[challengeId]/mission/create/_components/ChallengeCreateFunnel/FunnelRender.tsx
+++ b/src/app/(pages)/challenge/[challengeId]/mission/create/_components/ChallengeCreateFunnel/FunnelRender.tsx
@@ -1,33 +1,63 @@
+import { ValueOf } from 'next/dist/shared/lib/constants';
+import { useParams, useRouter } from 'next/navigation';
 import { type UseFunnelResults } from '@use-funnel/core';
+import useTempSave from '@/hooks/useTempSave';
 import type { FunnelProps } from './_context/context';
 import MissionDescription from './MissionDescription';
 import MissionPeriod from './MissionPeriod';
 import MissionPoint from './MissionPoint';
 
+interface FunnelRenderProps {
+  funnel: UseFunnelResults<FunnelProps, Partial<Record<string, unknown>>>;
+  updateDraftTempData: ReturnType<typeof useTempSave<FunnelProps>>['updateDraftTempData'];
+  autoSave: ReturnType<typeof useTempSave<FunnelProps>>['autoSave'];
+  clearTempData: ReturnType<typeof useTempSave<FunnelProps>>['clearTempData'];
+}
 
-export default function FunnelRender({ funnel }: { funnel: UseFunnelResults<FunnelProps, Partial<Record<string, unknown>>> }) {
+export default function FunnelRender({ funnel, updateDraftTempData, autoSave, clearTempData }: FunnelRenderProps) {
+  const router = useRouter();
+  const params = useParams();
+  const challengeId = params.challengeId;
+
+  const onSubmit = (props: ValueOf<FunnelProps>) => {
+    console.log({ ...funnel.context, ...props });
+    clearTempData();
+    router.push(`/challenge/${challengeId}`);
+  };
+
   return (
     <>
       <funnel.Render
         missionDescription={({ context, history }) => (
           <MissionDescription
             {...context}
-            onNext={(props) => history.push('missionPeriod', props)}
+            onNext={(props) => {
+              autoSave(context);
+              history.push('missionPeriod', props);
+            }}
             goBack={() => history.back()}
+            updateDraftTempData={updateDraftTempData}
           />
         )}
         missionPeriod={({ context, history }) => (
           <MissionPeriod
             {...context}
-            onNext={(props) => history.push('missionPoint', props)}
+            onNext={(props) => {
+              autoSave(context);
+              history.push('missionPoint', props);
+            }}
             goBack={() => history.back()}
+            updateDraftTempData={updateDraftTempData}
           />
         )}
         missionPoint={({ context, history }) => (
           <MissionPoint
             {...context}
-            onNext={(props) => history.push('missionPoint', props)}
+            onNext={(props) => {
+              onSubmit(props);
+            }}
             goBack={() => history.back()}
+            updateDraftTempData={updateDraftTempData}
           />
         )}
       />

--- a/src/app/(pages)/challenge/[challengeId]/mission/create/_components/ChallengeCreateFunnel/MissionDescription.tsx
+++ b/src/app/(pages)/challenge/[challengeId]/mission/create/_components/ChallengeCreateFunnel/MissionDescription.tsx
@@ -1,10 +1,10 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Button from '@/components/button/Button';
 import FunnelUi from '@/components/funnel/FunnelUi';
 import ImageFileInput from '@/components/input/ImageFileInput';
 import { Input, TextArea } from '@/components/input/Input';
-import type { MissionDescription } from './_context/context';
-
+import useTempSave from '@/hooks/useTempSave';
+import type { FunnelProps, MissionDescription } from './_context/context';
 
 interface MissionDescriptionProps {
   onNext: (props: MissionDescription) => void;
@@ -12,15 +12,20 @@ interface MissionDescriptionProps {
   name?: MissionDescription['name'];
   description?: MissionDescription['description'];
   pictures?: MissionDescription['pictures'];
+  updateDraftTempData: ReturnType<typeof useTempSave<FunnelProps>>['updateDraftTempData'];
 }
 
 const MAX_PICTURES = 3;
 const { Title, FieldWrapper, ButtonWrapper, GrayText, Label, TextRow } = FunnelUi;
 
-export default function MissionDescription({ onNext, ...props }: MissionDescriptionProps) {
+export default function MissionDescription({ onNext, updateDraftTempData, ...props }: MissionDescriptionProps) {
   const [name, setName] = useState<string>(props.name ?? '');
   const [description, setDescription] = useState<string>(props.description ?? '');
   const [pictures, setPictures] = useState<FileList | null>(props.pictures || null);
+
+  useEffect(() => {
+    updateDraftTempData({ name, description, pictures });
+  }, [name, description, pictures, updateDraftTempData]);
 
   return (
     <FunnelUi>

--- a/src/app/(pages)/challenge/[challengeId]/mission/create/_components/ChallengeCreateFunnel/MissionPeriod.tsx
+++ b/src/app/(pages)/challenge/[challengeId]/mission/create/_components/ChallengeCreateFunnel/MissionPeriod.tsx
@@ -6,11 +6,13 @@ import FunnelUi from '@/components/funnel/FunnelUi';
 import InputDate from '@/components/input/InputDate';
 import InputTime from '@/components/input/InputTime';
 import { isTimeValid } from '@/components/wheel-time-picker/TimePicker';
+import useTempSave from '@/hooks/useTempSave';
 import { Days, getKoreanDayString } from '@/utils/getKoreanDay';
 import MissionPeriodDrawer from '../drawer/MissionDateDrawer';
 import MissionTimeDrawer from '../drawer/MissionTimeDrawer';
 import WeeklyToggleSwitches from '../WeeklyToggleSwitches';
-import type { MissionPeriod } from './_context/context';
+import type { FunnelProps, MissionPeriod } from './_context/context';
+
 
 interface MissionPeriodProps {
   onNext: (props: MissionPeriod) => void;
@@ -19,6 +21,8 @@ interface MissionPeriodProps {
   endDate?: MissionPeriod['endDate'];
   startTime?: MissionPeriod['startTime'];
   endTime?: MissionPeriod['endTime'];
+  selectedDays?: MissionPeriod['selectedDays'];
+  updateDraftTempData: ReturnType<typeof useTempSave<FunnelProps>>['updateDraftTempData'];
 }
 
 export type TimeValue = {
@@ -29,11 +33,14 @@ export type TimeValue = {
 
 const { Title, FieldWrapper, ButtonWrapper, GrayText, Label, TextRow } = FunnelUi;
 
-export default function MissionPeriod({ onNext }: MissionPeriodProps) {
-  const [dateRange, setDateRange] = useState<DateRange>();
-  const [selectedDays, setSelectedDays] = useState<Days[]>([]);
-  const [startTime, setStartTime] = useState<TimeLike>();
-  const [endTime, setEndTime] = useState<TimeLike>();
+export default function MissionPeriod({ onNext, updateDraftTempData, ...props }: MissionPeriodProps) {
+  const [dateRange, setDateRange] = useState<DateRange | undefined>({
+    from: props.startDate ?? undefined,
+    to: props.endDate ?? undefined,
+  });
+  const [selectedDays, setSelectedDays] = useState<Days[]>(props.selectedDays ?? []);
+  const [startTime, setStartTime] = useState<TimeLike>(props.startTime ?? '');
+  const [endTime, setEndTime] = useState<TimeLike>(props.endTime ?? '');
   const [isValidTime, setIsValidTime] = useState(true);
 
   const setStartDate = (date: Date | null | undefined, type: 'from' | 'to') => {
@@ -51,6 +58,10 @@ export default function MissionPeriod({ onNext }: MissionPeriodProps) {
 
     setIsValidTime(isValid);
   }, [startTime, endTime]);
+
+  useEffect(() => {
+    updateDraftTempData({ startDate: dateRange?.from, endDate: dateRange?.to, startTime, endTime, selectedDays });
+  }, [dateRange, startTime, endTime, selectedDays, updateDraftTempData]);
 
   return (
     <FunnelUi>
@@ -87,7 +98,7 @@ export default function MissionPeriod({ onNext }: MissionPeriodProps) {
           <GrayText>반복 주기를 선택하면 더 재미있을 거예요!</GrayText>
         </TextRow>
         <div className='my-2'>
-          <WeeklyToggleSwitches setSelectedDays={setSelectedDays} />
+          <WeeklyToggleSwitches selectedDays={selectedDays} setSelectedDays={setSelectedDays} />
           <p className='mt-2 text-right'>
             {selectedDays.length > 0 ? (
               <>

--- a/src/app/(pages)/challenge/[challengeId]/mission/create/_components/ChallengeCreateFunnel/MissionPoint.tsx
+++ b/src/app/(pages)/challenge/[challengeId]/mission/create/_components/ChallengeCreateFunnel/MissionPoint.tsx
@@ -1,21 +1,28 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Button from '@/components/button/Button';
 import FunnelUi from '@/components/funnel/FunnelUi';
 import { Input } from '@/components/input/Input';
-import type { MissionPoint } from './_context/context';
+import useTempSave from '@/hooks/useTempSave';
+import type { FunnelProps, MissionPoint } from './_context/context';
 
 interface MissionPointProps {
   onNext: (props: MissionPoint) => void;
   goBack: () => void;
   point?: MissionPoint['point'];
+  updateDraftTempData: ReturnType<typeof useTempSave<FunnelProps>>['updateDraftTempData'];
 }
 
 const { Title, FieldWrapper, ButtonWrapper, GrayText, Label } = FunnelUi;
 const MAX_POINT = 100;
 const MIN_POINT = 1;
 
-export default function MissionPoint({ onNext, ...props }: MissionPointProps) {
+export default function MissionPoint({ onNext, updateDraftTempData, ...props }: MissionPointProps) {
   const [point, setPoint] = useState<number>(props.point ?? 0);
+
+  useEffect(() => {
+    updateDraftTempData({ point });
+  }, [point, updateDraftTempData]);
+
   return (
     <FunnelUi>
       <Title>
@@ -33,7 +40,7 @@ export default function MissionPoint({ onNext, ...props }: MissionPointProps) {
           <Input
             type='numberpad'
             value={point}
-            onChange={(e) => setPoint(Number(e.target.value) > MAX_POINT ? MAX_POINT : Number(e.target.value))}
+            onChange={(e) => setPoint(Number(e.target.value) > MAX_POINT ? 8 : Number(e.target.value))}
             maxLength={3}
             max={MAX_POINT}
             min={MIN_POINT}

--- a/src/app/(pages)/challenge/[challengeId]/mission/create/_components/ChallengeCreateFunnel/_context/context.ts
+++ b/src/app/(pages)/challenge/[challengeId]/mission/create/_components/ChallengeCreateFunnel/_context/context.ts
@@ -1,5 +1,5 @@
 import { TimeLike } from 'fs';
-
+import { Days } from '@/utils/getKoreanDay';
 
 export type MissionDescription = { name?: string; description?: string; pictures?: FileList | null };
 export type MissionPeriod = {
@@ -7,6 +7,7 @@ export type MissionPeriod = {
   endDate?: Date | null;
   startTime?: TimeLike;
   endTime?: TimeLike;
+  selectedDays?: Days[];
 };
 export type MissionPoint = { point?: number };
 

--- a/src/app/(pages)/challenge/[challengeId]/mission/create/_components/WeeklyToggleSwitches.tsx
+++ b/src/app/(pages)/challenge/[challengeId]/mission/create/_components/WeeklyToggleSwitches.tsx
@@ -11,7 +11,7 @@ function DayToggle({ day, isActive, onToggle }: DayToggleProps) {
   return (
     <button
       type='button'
-      className={`xs:h-11 xs:w-11 flex h-8 w-8 cursor-pointer items-center justify-center rounded-full border-[1px] border-v1-text-primary-200 text-sm font-bold transition-colors ${isActive ? 'bg-v1-orange-500 text-white' : 'bg-white'}`}
+      className={`flex h-8 w-8 cursor-pointer items-center justify-center rounded-full border-[1px] border-v1-text-primary-200 text-sm font-bold transition-colors xs:h-11 xs:w-11 ${isActive ? 'bg-v1-orange-500 text-white' : 'bg-white'}`}
       onClick={onToggle}
     >
       {getKoreanDayName(day)}
@@ -20,18 +20,20 @@ function DayToggle({ day, isActive, onToggle }: DayToggleProps) {
 }
 
 export default function WeeklyToggleSwitches({
+  selectedDays,
   setSelectedDays,
 }: {
+  selectedDays: Days[];
   setSelectedDays: Dispatch<SetStateAction<Days[]>>;
 }) {
   const [days, setDays] = useState<Record<Days, boolean>>({
-    Monday: false,
-    Tuesday: false,
-    Wednesday: false,
-    Thursday: false,
-    Friday: false,
-    Saturday: false,
-    Sunday: false,
+    Monday: selectedDays.includes('Monday'),
+    Tuesday: selectedDays.includes('Tuesday'),
+    Wednesday: selectedDays.includes('Wednesday'),
+    Thursday: selectedDays.includes('Thursday'),
+    Friday: selectedDays.includes('Friday'),
+    Saturday: selectedDays.includes('Saturday'),
+    Sunday: selectedDays.includes('Sunday'),
   });
 
   const toggleDay = (day: Days) => {

--- a/src/app/(pages)/challenge/[challengeId]/mission/create/_components/drawer/MissionDateDrawer.tsx
+++ b/src/app/(pages)/challenge/[challengeId]/mission/create/_components/drawer/MissionDateDrawer.tsx
@@ -4,7 +4,7 @@ import { Calendar } from '@/components/ui/calendar';
 import { Drawer, DrawerContent, DrawerDescription, DrawerTitle, DrawerTrigger } from '@/components/ui/drawer';
 import DrawButtonBox from '../ChallengeCreateFunnel/DrawButtonBox';
 
-export default function MissionPeriodDrawer({
+export default function MissionDateDrawer({
   dateRange,
   setDateRange,
   children,
@@ -16,7 +16,7 @@ export default function MissionPeriodDrawer({
   const [open, setOpen] = useState(false);
 
   const handleReset = () => {
-    setDateRange(undefined);
+    setDateRange({ from: undefined, to: undefined });
   };
 
   return (
@@ -38,7 +38,7 @@ export default function MissionPeriodDrawer({
           <DrawButtonBox
             handleReset={handleReset}
             setOpen={setOpen}
-            isSelected={!!dateRange?.from && !!dateRange?.to }
+            isSelected={!!dateRange?.from && !!dateRange?.to}
             buttonText={{
               selected: '선택 완료',
               unselected: '선택 해주세요',

--- a/src/app/(pages)/challenge/[challengeId]/mission/create/page.tsx
+++ b/src/app/(pages)/challenge/[challengeId]/mission/create/page.tsx
@@ -4,6 +4,6 @@ const DynamicPage = dynamic(() => import('./DynamicPage'), {
   ssr: false,
 });
 
-export default function Page(props: { searchParams: { temp: string } }) {
-  return <DynamicPage {...props} />;
+export default function Page() {
+  return <DynamicPage />;
 }

--- a/src/app/(pages)/challenge/[challengeId]/mission/create/page.tsx
+++ b/src/app/(pages)/challenge/[challengeId]/mission/create/page.tsx
@@ -1,47 +1,9 @@
-'use client';
+import dynamic from 'next/dynamic';
 
-import { useRouter } from 'next/navigation';
-import { useFunnel } from '@use-funnel/browser';
-import { Chevron, X } from '@/assets/images/icons';
-import FunnelUi from '@/components/funnel/FunnelUi';
-import Header from '@/components/layout/Header';
-import PageLayout from '@/components/layout/PageLayout';
-import { type FunnelProps } from './_components/ChallengeCreateFunnel/_context/context';
-import FunnelRender from './_components/ChallengeCreateFunnel/FunnelRender';
+const DynamicPage = dynamic(() => import('./DynamicPage'), {
+  ssr: false,
+});
 
-
-export default function Page() {
-  const router = useRouter();
-  const funnel = useFunnel<FunnelProps>({
-    id: 'challenge-create-funnel',
-    initial: {
-      step: 'missionDescription',
-      context: {},
-    },
-  });
-
-  return (
-    <PageLayout
-      className='px-6'
-      header={
-        <Header className='border-none bg-v1-background'>
-          <Header.Item>
-            {funnel.index > 0 ? (
-              <Header.Icon Icon={Chevron} onClick={() => funnel.history.back()} />
-            ) : (
-              <Header.Icon Icon={X} onClick={() => router.back()} />
-            )}
-          </Header.Item>
-          <Header.Title>
-            <FunnelUi.StepIndicator index={funnel.index} max={3} />
-          </Header.Title>
-          <Header.Item>
-            <Header.GrayText disabled={true}>임시저장</Header.GrayText>
-          </Header.Item>
-        </Header>
-      }
-    >
-      <FunnelRender funnel={funnel} />
-    </PageLayout>
-  );
+export default function Page(props: { searchParams: { temp: string } }) {
+  return <DynamicPage {...props} />;
 }

--- a/src/hooks/useTempSave.test.ts
+++ b/src/hooks/useTempSave.test.ts
@@ -1,0 +1,81 @@
+import { act, renderHook } from '@testing-library/react';
+import { type FunnelProps } from '@/app/(pages)/challenge/[challengeId]/mission/create/_components/ChallengeCreateFunnel/_context/context';
+import useTempSave from './useTempSave';
+
+describe('useTempSave', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('초기 상태가 올바르게 설정되어야 함', () => {
+    const { result } = renderHook(() => useTempSave({ id: 'mission-create' }));
+
+    expect(result.current.isSaving).toBe(false);
+    expect(result.current.savedTempData).toEqual(undefined);
+    expect(result.current.draftTempData).toEqual(undefined);
+  });
+
+  it('초기 상태에 로컬스토리지 값을 반영해야 함', () => {
+    window.localStorage.setItem('mission-create', JSON.stringify({ name: '저장된 미션' }));
+    const { result } = renderHook(() => useTempSave<FunnelProps>({ id: 'mission-create' }));
+
+    expect(result.current.savedTempData).toEqual({ name: '저장된 미션' });
+    expect(result.current.draftTempData).toEqual({ name: '저장된 미션' });
+  });
+
+  it('saveTempData가 데이터를 localStorage에 저장하고 isSaving을 true로 설정해야 함', () => {
+    const { result } = renderHook(() => useTempSave<FunnelProps>({ id: 'mission-create' }));
+
+    act(() => {
+      result.current.saveTempData({ name: '저장된 미션' });
+    });
+
+    expect(result.current.isSaving).toBe(true);
+    expect(result.current.savedTempData).toEqual({ name: '저장된 미션' });
+  });
+
+  it('updateDraftTempData가 미저장 데이터를 업데이트해야 함', () => {
+    const { result } = renderHook(() => useTempSave<FunnelProps>({ id: 'mission-create' }));
+
+    act(() => {
+      result.current.saveTempData({ name: '저장된 미션' });
+      result.current.updateDraftTempData({ name: '새로운 미션' });
+    });
+
+    expect(result.current.draftTempData).toEqual({ name: '새로운 미션' });
+  });
+
+  it('clearTempData가 데이터를 초기화해야 함', () => {
+    const { result } = renderHook(() => useTempSave<FunnelProps>({ id: 'mission-create' }));
+
+    act(() => {
+      result.current.saveTempData({ name: '저장된 미션' });
+      result.current.clearTempData();
+    });
+
+    expect(result.current.isSaving).toBe(false);
+    expect(result.current.savedTempData).toEqual(undefined);
+    expect(result.current.draftTempData).toEqual(undefined);
+  });
+
+  it('autoSave가 isSaving이 true일 때만 데이터를 저장해야 함', () => {
+    const { result } = renderHook(() => useTempSave<FunnelProps>({ id: 'mission-create' }));
+
+    // isSaving: false
+    act(() => {
+      result.current.autoSave({ name: '자동 저장 미션' });
+    });
+    expect(result.current.savedTempData).toEqual(undefined);
+
+    // isSaving을 true로 설정
+    act(() => {
+      result.current.saveTempData({ name: '첫 번째 저장' });
+    });
+
+    // isSaving: true
+    act(() => {
+      result.current.autoSave({ name: '자동 저장 미션' });
+    });
+    expect(result.current.savedTempData).toEqual({ name: '자동 저장 미션' });
+  });
+});

--- a/src/hooks/useTempSave.ts
+++ b/src/hooks/useTempSave.ts
@@ -1,13 +1,12 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { ValueOf } from 'next/dist/shared/lib/constants';
 import { useLocalStorage } from 'react-use';
 
-
 type TemporarySaveType = 'mission-create';
 
-export default function useTempSave<T>({ id, useTempData }: { id: TemporarySaveType; useTempData: boolean }) {
+export default function useTempSave<T>({ id }: { id: TemporarySaveType }) {
   const [savedTempData, setSavedTempData, removeSavedTempData] = useLocalStorage(id) as unknown as [
     ValueOf<T> | null,
     (value: ValueOf<T> | null) => void,
@@ -40,12 +39,6 @@ export default function useTempSave<T>({ id, useTempData }: { id: TemporarySaveT
     setDraftTempData({} as ValueOf<T>);
     setIsSaving(false);
   }, [removeSavedTempData]);
-
-  useEffect(() => {
-    if (!useTempData && !isSaving) {
-      clearTempData();
-    }
-  }, [useTempData, clearTempData, isSaving]);
 
   return {
     isSaving,

--- a/src/hooks/useTempSave.ts
+++ b/src/hooks/useTempSave.ts
@@ -1,0 +1,59 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { ValueOf } from 'next/dist/shared/lib/constants';
+import { useLocalStorage } from 'react-use';
+
+
+type TemporarySaveType = 'mission-create';
+
+export default function useTempSave<T>({ id, useTempData }: { id: TemporarySaveType; useTempData: boolean }) {
+  const [savedTempData, setSavedTempData, removeSavedTempData] = useLocalStorage(id) as unknown as [
+    ValueOf<T> | null,
+    (value: ValueOf<T> | null) => void,
+    () => void,
+  ];
+  const [draftTempData, setDraftTempData] = useState<ValueOf<T>>(savedTempData as ValueOf<T>);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const updateDraftTempData = useCallback(
+    (newData: ValueOf<T>) => {
+      const updatedTempData = { ...savedTempData, ...newData };
+      setDraftTempData(updatedTempData);
+    },
+    [savedTempData],
+  );
+
+  const saveTempData = (context: ValueOf<T>) => {
+    setSavedTempData({ ...context, ...draftTempData });
+    setIsSaving(true);
+  };
+
+  const autoSave = (context: ValueOf<T>) => {
+    if (isSaving) {
+      saveTempData(context);
+    }
+  };
+
+  const clearTempData = useCallback(() => {
+    removeSavedTempData();
+    setDraftTempData({} as ValueOf<T>);
+    setIsSaving(false);
+  }, [removeSavedTempData]);
+
+  useEffect(() => {
+    if (!useTempData && !isSaving) {
+      clearTempData();
+    }
+  }, [useTempData, clearTempData, isSaving]);
+
+  return {
+    isSaving,
+    tempData: savedTempData,
+    draftTempData,
+    saveTempData,
+    autoSave,
+    clearTempData,
+    updateDraftTempData,
+  };
+}

--- a/src/hooks/useTempSave.ts
+++ b/src/hooks/useTempSave.ts
@@ -4,15 +4,16 @@ import { useCallback, useState } from 'react';
 import { ValueOf } from 'next/dist/shared/lib/constants';
 import { useLocalStorage } from 'react-use';
 
-type TemporarySaveType = 'mission-create';
+
+type TemporarySaveType = 'mission-create' | 'reward-create';
 
 export default function useTempSave<T>({ id }: { id: TemporarySaveType }) {
   const [savedTempData, setSavedTempData, removeSavedTempData] = useLocalStorage(id) as unknown as [
-    ValueOf<T> | null,
-    (value: ValueOf<T> | null) => void,
+    ValueOf<T> | undefined,
+    (value: ValueOf<T> | undefined) => void,
     () => void,
   ];
-  const [draftTempData, setDraftTempData] = useState<ValueOf<T>>(savedTempData as ValueOf<T>);
+  const [draftTempData, setDraftTempData] = useState(savedTempData);
   const [isSaving, setIsSaving] = useState(false);
 
   const updateDraftTempData = useCallback(
@@ -36,13 +37,13 @@ export default function useTempSave<T>({ id }: { id: TemporarySaveType }) {
 
   const clearTempData = useCallback(() => {
     removeSavedTempData();
-    setDraftTempData({} as ValueOf<T>);
+    setDraftTempData(undefined);
     setIsSaving(false);
   }, [removeSavedTempData]);
 
   return {
     isSaving,
-    tempData: savedTempData,
+    savedTempData,
     draftTempData,
     saveTempData,
     autoSave,

--- a/src/utils/isVaildObject.ts
+++ b/src/utils/isVaildObject.ts
@@ -1,0 +1,9 @@
+export default function isVaildObject(obj: Record<string, unknown> | undefined | null) {
+  if (!obj) return false;
+  const conditions = [
+    typeof obj === 'object',
+    Object.keys(obj as object).length > 0,
+    Object.values(obj as object).some((value) => value),
+  ];
+  return conditions.every((condition) => condition);
+}


### PR DESCRIPTION
## 임시저장 기능 구현

- 미션 생성에 임시 저장 기능을 추가했습니다.
- 재사용을 위한 커스텀 훅을 작성했습니다.

## 리뷰어에게 전할 말

### 커스텀훅 useTempSave.ts의 동작 방식에 대해서

- [src/hooks/useTempSave.ts](https://github.com/Jak-Sim/client-web/blob/305ef0b3b65ad8de8772c073336da5ad6b8da04c/src/hooks/useTempSave.ts)
```tsx
function useTempSave<T>({ id }: {
    id: TemporarySaveType;
}): {
    isSaving: boolean;
    savedTempData: ValueOf<T> | undefined;
    draftTempData: ValueOf<T> | undefined;
    saveTempData: (context: ValueOf<T>) => void;
    autoSave: (context: ValueOf<T>) => void;
    clearTempData: () => void;
    updateDraftTempData: (newData: ValueOf<T>) => void;
}
```

훅을 실행 시 **로컬스토리지에 저장된 값이 존재할 경우, 해당 값을 임시저장 값으로 초기화**하도록 설계했습니다.
즉, 훅 내부에 임시저장을 사용할지/말지/지울지 여부에 따라 동작하는 로직은 **포함되어 있지 않습니다.**

사용자가 이전 tempData 없이 새로 작성을 원할 경우, 리디렉션 전에서 로컬스토리지를 비우고 이동하는 흐름입니다.
미션 생성 페이지에서 searchParams 등을 통해 부수효과를 처리하지 않는 방식으로 구현했습니다.

따라서 이전 router에 useTempSave를 위한 관련 로직이 필요하게 되었지만
다른 훅에 전달할 useTempSave의 반환값이 파편화되지 않도록 유지함으로써 흐름을 단순화하고 버그를 줄이는 데 초점을 맞추는 것이
로직을 하나의 훅에 응집시키는 것 이상의 이점을 제공한다고 생각해서, 마무리 단계에서 해당 방향으로 리팩토링을 완료했습니다.

- 예시: NewMission.tsx

https://github.com/Jak-Sim/client-web/blob/305ef0b3b65ad8de8772c073336da5ad6b8da04c/src/app/(pages)/challenge/%5BchallengeId%5D/_components/NewMission.tsx#L28-L31

## 시연영상

https://github.com/user-attachments/assets/3f8d3632-bae1-40ad-a498-3d721275c4bc

## 단위테스트
- 커스텀훅 단위테스트 진행했습니다
<img width="841" alt="image" src="https://github.com/user-attachments/assets/806b2997-9bfe-4c96-a280-493aee185fe5" />
<img width="1005" alt="image" src="https://github.com/user-attachments/assets/9689cb99-872e-4b65-a9f4-e38b574b654a" />

