### PR TITLE
feat: 위로가기 버튼 추가

### DIFF
--- a/src/app/(pages)/challenge/_components/ChallengeDetail.tsx
+++ b/src/app/(pages)/challenge/_components/ChallengeDetail.tsx
@@ -1,26 +1,29 @@
 'use client';
 
+import { useRef } from 'react';
 import Image from 'next/image';
 import { differenceInDays } from 'date-fns';
 import { Fire, Gem, Lightning } from '@/assets/images/icons';
 import Accodion from '@/components/accodion/Accodion';
 import Chip from '@/components/chip/Chip';
 import { type ChallengeType } from '@/models/challenge/Challenge';
-import dummyMission from '../_mock/dummyMission.json';
+import dummyMissionLengthTen from '../_mock/dummyMissionLengthTen.json';
 import dummyReward from '../_mock/dummyReward.json';
 import MissionList from './MissionList';
 import ParticipantList from './ParticipantList';
 import RewardList from './RewardList';
+import TopButton from './TopButton';
 
 export default function ChallengeDetail({ challenge }: { challenge: ChallengeType }) {
   const currentChallengeStreak = differenceInDays(new Date(), new Date(challenge.createdAt)).toString();
+  const scrollRef = useRef<HTMLDivElement>(null);
 
   // TODO: API 연동 필요한 값: rewards, missions
   const rewards = dummyReward;
-  const missions = dummyMission;
+  const missions = dummyMissionLengthTen;
 
   return (
-    <div className='flex flex-col gap-5 px-6 py-2 pb-10'>
+    <div className='flex flex-col gap-5 px-6 py-2 pb-10' ref={scrollRef}>
       <SectionCard>
         <div className='relative w-full rounded-t-xl bg-v1-subtext-200 pb-[62.5%]'>
           {challenge.backgroundImage && (
@@ -87,6 +90,8 @@ export default function ChallengeDetail({ challenge }: { challenge: ChallengeTyp
           </Accodion.Content>
         </Accodion>
       </SectionCard>
+
+      {missions.length > 9 && <TopButton scrollRef={scrollRef} />}
 
       <SectionCard>
         <Accodion defaultOpen={true}>

--- a/src/app/(pages)/challenge/_components/TopButton.tsx
+++ b/src/app/(pages)/challenge/_components/TopButton.tsx
@@ -1,0 +1,14 @@
+import { AlignUp } from '@/assets/images/icons';
+
+export default function TopButton({ scrollRef }: { scrollRef: React.RefObject<HTMLDivElement> }) {
+  const toTop = () => {
+    scrollRef.current?.scrollIntoView({ behavior: 'smooth' });
+  };
+
+  return (
+    <button onClick={toTop} className='flex items-center justify-center gap-2 text-lg text-v1-text-primary-400'>
+      <AlignUp />
+      위로 가기
+    </button>
+  );
+}

--- a/src/app/(pages)/challenge/_mock/dummyMission.json
+++ b/src/app/(pages)/challenge/_mock/dummyMission.json
@@ -23,10 +23,25 @@
       "name": "리워드 이름",
       "description": "리워드 설명",
       "remain": 10,
-      "point": 300,
+      "point": 25,
       "needConfirm": false
     },
     "day": ["토", "일"],
+    "time": null
+  },
+  {
+    "id": 3,
+    "name": "미션 이름",
+    "description": "미션 설명",
+    "reward": {
+      "id": 2,
+      "name": "리워드 이름",
+      "description": "리워드 설명",
+      "remain": 10,
+      "point": 50,
+      "needConfirm": false
+    },
+    "day": ["월", "화", "수", "목", "금", "토", "일"],
     "time": null
   }
 ]

--- a/src/app/(pages)/challenge/_mock/dummyMissionLengthTen.json
+++ b/src/app/(pages)/challenge/_mock/dummyMissionLengthTen.json
@@ -1,0 +1,152 @@
+[
+  {
+    "id": 1,
+    "name": "미션 이름",
+    "description": "미션 설명",
+    "reward": {
+      "id": 1,
+      "name": "리워드 이름",
+      "description": "리워드 설명",
+      "remain": 10,
+      "point": 100,
+      "needConfirm": true
+    },
+    "day": ["월", "수"],
+    "time": { "start": "10:00", "end": "21:00" }
+  },
+  {
+    "id": 2,
+    "name": "미션 이름",
+    "description": "미션 설명",
+    "reward": {
+      "id": 2,
+      "name": "리워드 이름",
+      "description": "리워드 설명",
+      "remain": 10,
+      "point": 25,
+      "needConfirm": false
+    },
+    "day": ["토", "일"],
+    "time": null
+  },
+  {
+    "id": 3,
+    "name": "미션 이름",
+    "description": "미션 설명",
+    "reward": {
+      "id": 2,
+      "name": "리워드 이름",
+      "description": "리워드 설명",
+      "remain": 10,
+      "point": 50,
+      "needConfirm": false
+    },
+    "day": ["월", "화", "수", "목", "금", "토", "일"],
+    "time": null
+  },
+  {
+    "id": 4,
+    "name": "미션 이름",
+    "description": "미션 설명",
+    "reward": {
+      "id": 2,
+      "name": "리워드 이름",
+      "description": "리워드 설명",
+      "remain": 10,
+      "point": 10,
+      "needConfirm": false
+    },
+    "day": ["토", "일"],
+    "time": null
+  },
+  {
+    "id": 5,
+    "name": "미션 이름",
+    "description": "미션 설명",
+    "reward": {
+      "id": 2,
+      "name": "리워드 이름",
+      "description": "리워드 설명",
+      "remain": 10,
+      "point": 90,
+      "needConfirm": false
+    },
+    "day": ["금", "토", "일"],
+    "time": null
+  },
+  {
+    "id": 6,
+    "name": "미션 이름",
+    "description": "미션 설명",
+    "reward": {
+      "id": 2,
+      "name": "리워드 이름",
+      "description": "리워드 설명",
+      "remain": 10,
+      "point": 30,
+      "needConfirm": false
+    },
+    "day": ["토", "일"],
+    "time": null
+  },
+  {
+    "id": 7,
+    "name": "미션 이름",
+    "description": "미션 설명",
+    "reward": {
+      "id": 2,
+      "name": "리워드 이름",
+      "description": "리워드 설명",
+      "remain": 10,
+      "point": 22,
+      "needConfirm": false
+    },
+    "day": ["토", "일"],
+    "time": null
+  },
+  {
+    "id": 8,
+    "name": "미션 이름",
+    "description": "미션 설명",
+    "reward": {
+      "id": 2,
+      "name": "리워드 이름",
+      "description": "리워드 설명",
+      "remain": 10,
+      "point": 85,
+      "needConfirm": false
+    },
+    "day": ["토", "일"],
+    "time": null
+  },
+  {
+    "id": 9,
+    "name": "미션 이름",
+    "description": "미션 설명",
+    "reward": {
+      "id": 2,
+      "name": "리워드 이름",
+      "description": "리워드 설명",
+      "remain": 10,
+      "point": 1,
+      "needConfirm": false
+    },
+    "day": ["토", "일"],
+    "time": null
+  },
+  {
+    "id": 10,
+    "name": "미션 이름",
+    "description": "미션 설명",
+    "reward": {
+      "id": 2,
+      "name": "리워드 이름",
+      "description": "리워드 설명",
+      "remain": 10,
+      "point": 9,
+      "needConfirm": false
+    },
+    "day": ["토", "일"],
+    "time": null
+  }
+]

--- a/src/assets/images/icons/align-up.svg
+++ b/src/assets/images/icons/align-up.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M5 10.8611L10 6M10 6L15 10.8611M10 6L10 18M18 2L2 2" stroke="#323254" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/images/icons/index.ts
+++ b/src/assets/images/icons/index.ts
@@ -1,4 +1,5 @@
 import AddCircle from './add-circle.svg';
+import AlignUp from './align-up.svg';
 import ArrowRight from './arrow-right.svg';
 import ArrowLeft from './arrow-small-left.svg';
 import ArrowSmallRight from './arrow-small-right.svg';
@@ -66,6 +67,7 @@ export {
   SmallFlag,
   SmallBadge,
   Dots,
+  AlignUp,
   AvatarPlus,
   AddCircle,
   TailArrow,


### PR DESCRIPTION
# 위로가기 버튼 추가

- 챌린지 상세 페이지에서 미션이 10개 이상일 때 출력되는 위로가기 버튼을 추가했습니다.
- 미션이 10개 이상인 더미 데이터 추가했습니다.

```tsx
// 컴포넌트 내부 로직을 최소화하기 위해서 분기를 바깥으로 뺐어요
{missions.length > 9 && <TopButton scrollRef={scrollRef} />}
```

## 시연영상

https://github.com/user-attachments/assets/dbd5fb9c-93d8-4279-8009-785f556d7220

