### PR TITLE
feat: 리워드 생성 페이지 추가

### DIFF
--- a/src/app/(pages)/challenge/[challengeId]/mission/create/_components/ChallengeCreateFunnel/MissionPoint.tsx
+++ b/src/app/(pages)/challenge/[challengeId]/mission/create/_components/ChallengeCreateFunnel/MissionPoint.tsx
@@ -41,7 +41,6 @@ export default function MissionPoint({ onNext, updateDraftTempData, ...props }: 
             type='numberpad'
             value={point}
             onChange={(e) => setPoint(Number(e.target.value) > MAX_POINT ? 8 : Number(e.target.value))}
-            maxLength={3}
             max={MAX_POINT}
             min={MIN_POINT}
             className='w-full text-center'

--- a/src/app/(pages)/challenge/[challengeId]/reward/create/DynamicPage.tsx
+++ b/src/app/(pages)/challenge/[challengeId]/reward/create/DynamicPage.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useFunnel } from '@use-funnel/browser';
+import { Chevron, X } from '@/assets/images/icons';
+import FunnelUi from '@/components/funnel/FunnelUi';
+import Header from '@/components/layout/Header';
+import PageLayout from '@/components/layout/PageLayout';
+import useTempSave from '@/hooks/useTempSave';
+import isVaildObject from '@/utils/isVaildObject';
+import { type FunnelProps } from './_components/RewardCreateFunnel/_context/context';
+import FunnelRender from './_components/RewardCreateFunnel/FunnelRender';
+
+export default function DynamicPageContent() {
+  const router = useRouter();
+  const { saveTempData, autoSave, updateDraftTempData, draftTempData, savedTempData, clearTempData } =
+    useTempSave<FunnelProps>({
+      id: 'reward-create',
+    });
+  const funnel = useFunnel<FunnelProps>({
+    id: 'reward-create',
+    initial: {
+      step: 'rewardDescription',
+      context: savedTempData as FunnelProps['rewardDescription'],
+    },
+  });
+
+  return (
+    <PageLayout
+      className='px-6'
+      header={
+        <Header className='border-none bg-v1-background'>
+          <Header.Item>
+            {funnel.index > 0 ? (
+              <Header.Icon
+                Icon={Chevron}
+                onClick={() => {
+                  autoSave(funnel.context);
+                  funnel.history.back();
+                }}
+              />
+            ) : (
+              <Header.Icon Icon={X} onClick={() => router.back()} />
+            )}
+          </Header.Item>
+          <Header.Title>
+            <FunnelUi.StepIndicator index={funnel.index} max={3} />
+          </Header.Title>
+          <Header.Item>
+            <Header.GrayText disabled={!isVaildObject(draftTempData)}>
+              <button onClick={() => saveTempData(funnel.context)}>임시저장</button>
+            </Header.GrayText>
+          </Header.Item>
+        </Header>
+      }
+    >
+      <FunnelRender
+        funnel={funnel}
+        updateDraftTempData={updateDraftTempData}
+        autoSave={autoSave}
+        clearTempData={clearTempData}
+      />
+    </PageLayout>
+  );
+}

--- a/src/app/(pages)/challenge/[challengeId]/reward/create/DynamicPage.tsx
+++ b/src/app/(pages)/challenge/[challengeId]/reward/create/DynamicPage.tsx
@@ -44,7 +44,7 @@ export default function DynamicPageContent() {
             )}
           </Header.Item>
           <Header.Title>
-            <FunnelUi.StepIndicator index={funnel.index} max={3} />
+            <FunnelUi.StepIndicator index={funnel.index} max={2} />
           </Header.Title>
           <Header.Item>
             <Header.GrayText disabled={!isVaildObject(draftTempData)}>

--- a/src/app/(pages)/challenge/[challengeId]/reward/create/_components/RewardCreateFunnel/FunnelRender.tsx
+++ b/src/app/(pages)/challenge/[challengeId]/reward/create/_components/RewardCreateFunnel/FunnelRender.tsx
@@ -1,0 +1,55 @@
+import { ValueOf } from 'next/dist/shared/lib/constants';
+import { useRouter } from 'next/navigation';
+import { useParams } from 'next/navigation';
+import { type UseFunnelResults } from '@use-funnel/core';
+import useTempSave from '@/hooks/useTempSave';
+import type { FunnelProps } from './_context/context';
+import RewardDescription from './RewardDescription';
+import RewardPoint from './RewardPoint';
+
+interface FunnelRenderProps {
+  funnel: UseFunnelResults<FunnelProps, Partial<Record<string, unknown>>>;
+  updateDraftTempData: ReturnType<typeof useTempSave<FunnelProps>>['updateDraftTempData'];
+  autoSave: ReturnType<typeof useTempSave<FunnelProps>>['autoSave'];
+  clearTempData: ReturnType<typeof useTempSave<FunnelProps>>['clearTempData'];
+}
+
+export default function FunnelRender({ funnel, updateDraftTempData, autoSave, clearTempData }: FunnelRenderProps) {
+  const router = useRouter();
+  const params = useParams();
+  const challengeId = params.challengeId;
+
+  const onSubmit = (props: ValueOf<FunnelProps>) => {
+    console.log({ ...funnel.context, ...props });
+    clearTempData();
+    router.push(`/challenge/${challengeId}?tab=reward-page`);
+  };
+
+  return (
+    <>
+      <funnel.Render
+        rewardDescription={({ context, history }) => (
+          <RewardDescription
+            {...context}
+            onNext={(props) => {
+              autoSave(context);
+              history.push('rewardPoint', props);
+            }}
+            goBack={() => history.back()}
+            updateDraftTempData={updateDraftTempData}
+          />
+        )}
+        rewardPoint={({ context, history }) => (
+          <RewardPoint
+            {...context}
+            onNext={(props) => {
+              onSubmit(props);
+            }}
+            goBack={() => history.back()}
+            updateDraftTempData={updateDraftTempData}
+          />
+        )}
+      />
+    </>
+  );
+}

--- a/src/app/(pages)/challenge/[challengeId]/reward/create/_components/RewardCreateFunnel/RewardDescription.tsx
+++ b/src/app/(pages)/challenge/[challengeId]/reward/create/_components/RewardCreateFunnel/RewardDescription.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+import Button from '@/components/button/Button';
+import FunnelUi from '@/components/funnel/FunnelUi';
+import { Input, TextArea } from '@/components/input/Input';
+import useTempSave from '@/hooks/useTempSave';
+import type { FunnelProps, RewardDescription } from './_context/context';
+
+
+interface RewardDescriptionProps {
+  onNext: (props: RewardDescription) => void;
+  goBack: () => void;
+  name?: RewardDescription['name'];
+  description?: RewardDescription['description'];
+  updateDraftTempData: ReturnType<typeof useTempSave<FunnelProps>>['updateDraftTempData'];
+}
+
+const { Title, FieldWrapper, ButtonWrapper, Label } = FunnelUi;
+
+export default function RewardDescription({ onNext, updateDraftTempData, ...props }: RewardDescriptionProps) {
+  const [name, setName] = useState<string>(props.name ?? '');
+  const [description, setDescription] = useState<string>(props.description ?? '');
+
+  useEffect(() => {
+    updateDraftTempData({ name, description });
+  }, [name, description, updateDraftTempData]);
+
+  return (
+    <FunnelUi>
+      <Title>
+        <strong>리워드 상품</strong>을
+        <br />
+        등록해 주세요!
+      </Title>
+      <FieldWrapper>
+        <Label htmlFor='name'>리워드(보상) 상품 제목</Label>
+        <Input
+          type='text'
+          placeholder='리워드 상품 (최대 10자)'
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          maxLength={15}
+        >
+          <Input.LengthCounter />
+        </Input>
+      </FieldWrapper>
+      <FieldWrapper>
+        <Label htmlFor='description'>리워드(보상) 한 소개를 입력해 주세요</Label>
+        <TextArea
+          className='break-keep'
+          placeholder='리워드를 한줄로 소개해 주세요 (최대 30자)'
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          maxLength={30}
+        >
+          <TextArea.LengthCounter />
+        </TextArea>
+      </FieldWrapper>
+      <ButtonWrapper>
+        <Button onClick={() => onNext({ name, description })} disabled={!name || !description}>
+          다음
+        </Button>
+      </ButtonWrapper>
+    </FunnelUi>
+  );
+}

--- a/src/app/(pages)/challenge/[challengeId]/reward/create/_components/RewardCreateFunnel/RewardPoint.tsx
+++ b/src/app/(pages)/challenge/[challengeId]/reward/create/_components/RewardCreateFunnel/RewardPoint.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from 'react';
+import Button from '@/components/button/Button';
+import FunnelUi from '@/components/funnel/FunnelUi';
+import { Input } from '@/components/input/Input';
+import useTempSave from '@/hooks/useTempSave';
+import type { FunnelProps, RewardPoint } from './_context/context';
+
+interface RewardPointProps {
+  onNext: (props: RewardPoint) => void;
+  goBack: () => void;
+  point?: RewardPoint['point'];
+  count?: RewardPoint['count'];
+  updateDraftTempData: ReturnType<typeof useTempSave<FunnelProps>>['updateDraftTempData'];
+}
+
+const { Title, FieldWrapper, ButtonWrapper, GrayText, Label } = FunnelUi;
+const MAX_POINT = 100;
+const MIN_POINT = 1;
+const MAX_COUNT = 10;
+const MIN_COUNT = 1;
+
+export default function RewardPoint({ onNext, updateDraftTempData, ...props }: RewardPointProps) {
+  const [point, setPoint] = useState<number | undefined>(props.point);
+  const [count, setCount] = useState<number | undefined>(props.count);
+
+  useEffect(() => {
+    updateDraftTempData({ point, count });
+  }, [point, count, updateDraftTempData]);
+
+  return (
+    <FunnelUi>
+      <Title>
+        리워드 상품과 교환할 <br />
+        포인트를 등록해 주세요!
+      </Title>
+      <FieldWrapper>
+        <div>
+          <Label htmlFor='point'>소모 포인트</Label>
+          <GrayText>포인트를 설정하고 리워드와 교환 할수 있어요</GrayText>
+        </div>
+        <div className='flex items-center gap-2'>
+          <Input
+            type='numberpad'
+            placeholder='1~10000'
+            value={point}
+            onChange={(e) => setPoint(Number(e.target.value) > MAX_POINT ? MAX_POINT : Number(e.target.value))}
+            maxLength={3}
+            max={MAX_POINT}
+            min={MIN_POINT}
+            className='text-center'
+            maxWidth='230px'
+          />{' '}
+          포인트
+        </div>
+      </FieldWrapper>
+      <FieldWrapper>
+        <div>
+          <Label htmlFor='count'>리워드(보상) 개수 설정</Label>
+          <GrayText>리워드 개수를 설정</GrayText>
+        </div>
+        <div className='flex items-center justify-start gap-2'>
+          <Input
+            type='numberpad'
+            placeholder='1~10'
+            value={count}
+            onChange={(e) => setCount(Number(e.target.value) > MAX_COUNT ? MAX_COUNT : Number(e.target.value))}
+            className='text-center'
+            maxWidth='230px'
+            max={MAX_COUNT}
+            min={MIN_COUNT}
+          />{' '}
+          개
+        </div>
+      </FieldWrapper>
+      <ButtonWrapper>
+        <Button
+          onClick={() => onNext({ point, count })}
+          disabled={point === undefined || point < MIN_POINT || point > MAX_POINT}
+        >
+          {point === undefined ? '포인트를 입력해주세요' : '미션 생성 완료'}
+        </Button>
+      </ButtonWrapper>
+    </FunnelUi>
+  );
+}

--- a/src/app/(pages)/challenge/[challengeId]/reward/create/_components/RewardCreateFunnel/RewardPoint.tsx
+++ b/src/app/(pages)/challenge/[challengeId]/reward/create/_components/RewardCreateFunnel/RewardPoint.tsx
@@ -14,7 +14,7 @@ interface RewardPointProps {
 }
 
 const { Title, FieldWrapper, ButtonWrapper, GrayText, Label } = FunnelUi;
-const MAX_POINT = 100;
+const MAX_POINT = 10000;
 const MIN_POINT = 1;
 const MAX_COUNT = 10;
 const MIN_COUNT = 1;

--- a/src/app/(pages)/challenge/[challengeId]/reward/create/_components/RewardCreateFunnel/RewardPoint.tsx
+++ b/src/app/(pages)/challenge/[challengeId]/reward/create/_components/RewardCreateFunnel/RewardPoint.tsx
@@ -44,7 +44,6 @@ export default function RewardPoint({ onNext, updateDraftTempData, ...props }: R
             placeholder='1~10000'
             value={point}
             onChange={(e) => setPoint(Number(e.target.value) > MAX_POINT ? MAX_POINT : Number(e.target.value))}
-            maxLength={3}
             max={MAX_POINT}
             min={MIN_POINT}
             className='text-center'

--- a/src/app/(pages)/challenge/[challengeId]/reward/create/_components/RewardCreateFunnel/_context/context.ts
+++ b/src/app/(pages)/challenge/[challengeId]/reward/create/_components/RewardCreateFunnel/_context/context.ts
@@ -1,0 +1,7 @@
+export type RewardDescription = { name?: string; description?: string };
+export type RewardPoint = { point?: number; count?: number };
+
+export type FunnelProps = {
+  rewardDescription: RewardDescription;
+  rewardPoint: RewardPoint;
+};

--- a/src/app/(pages)/challenge/[challengeId]/reward/create/page.tsx
+++ b/src/app/(pages)/challenge/[challengeId]/reward/create/page.tsx
@@ -1,0 +1,9 @@
+import dynamic from 'next/dynamic';
+
+const DynamicPage = dynamic(() => import('./DynamicPage'), {
+  ssr: false,
+});
+
+export default function Page() {
+  return <DynamicPage />;
+}

--- a/src/components/input/Input.tsx
+++ b/src/components/input/Input.tsx
@@ -1,14 +1,17 @@
 import { createContext, useContext } from 'react';
 import { cn } from '@/lib/shadcn/utils';
 
+
 type InputProps = React.InputHTMLAttributes<HTMLInputElement> & {
   className?: string;
   children?: React.ReactNode;
+  maxWidth?: string;
 };
 
 type TextAreaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
   className?: string;
   children?: React.ReactNode;
+  maxWidth?: string;
 };
 
 const commonContext = createContext<{
@@ -20,10 +23,10 @@ const commonContext = createContext<{
 });
 const commonStyle = 'w-full rounded-2xl bg-v1-text-primary-50 p-3 outline-none text-xl';
 
-function Input({ children, className, ...props }: InputProps) {
+function Input({ children, className, maxWidth, ...props }: InputProps) {
   return (
     <commonContext.Provider value={{ length: props.value?.toString().length || 0, maxLength: props.maxLength || 0 }}>
-      <div className='relative flex flex-1 flex-col gap-1'>
+      <div className='relative flex flex-1 flex-col gap-1' style={{ maxWidth }}>
         <input className={cn(commonStyle, className)} {...props} />
         {children}
       </div>
@@ -31,10 +34,10 @@ function Input({ children, className, ...props }: InputProps) {
   );
 }
 
-function TextArea({ children, className, ...props }: TextAreaProps) {
+function TextArea({ children, className, maxWidth, ...props }: TextAreaProps) {
   return (
     <commonContext.Provider value={{ length: props.value?.toString().length || 0, maxLength: props.maxLength || 0 }}>
-      <div className='relative flex flex-col gap-1'>
+      <div className='relative flex flex-col gap-1' style={{ maxWidth }}>
         <textarea className={cn('min-h-[150px]', commonStyle, className)} {...props} />
         {children}
       </div>


### PR DESCRIPTION
# 리워드 생성 페이지 추가

- 리워드 생성 페이지 퍼널 추가
- 임시저장 기능 연결
- 리디렉션 확인

## 시연 영상

https://github.com/user-attachments/assets/079f6ad6-8558-47d5-9bbe-3925a676909d

## 기능 상세

### **퍼널 동작:** 
- Step 이동 / 다음 버튼 활성화 / StepIndicator 동작

### **리디렉션:** 

- 리워드를 작성 완료하거나 뒤로 가기 아이콘 클릭 시, 챌린지 페이지의 **보상 페이지 탭**으로 돌아갑니다.

### **리워드 작성 팝업:**
<img src="https://github.com/user-attachments/assets/e6d473c4-6fec-4c8d-97b1-fccaaa0aaa2e" width="300">

- 로컬스토리지에 임시저장 값이 있을 시, 팝업이 오픈됩니다.
  - 계속 작성하기: 이어서 작성
  - 새 리워드 작성하기: 새로 작성   

### onSubmit
- onSubmit 시, 최종 전달될 context를 console.log에서 확인 가능합니다.
<img src="https://github.com/user-attachments/assets/b2bbba41-b7f2-4c46-9073-61c8a8438729" width="450">

### **임시저장**

```tsx
useTempSave<FunnelProps>({
  id: 'reward-create',
});
```

- 로컬 스토리지 내 reward-create키로 저장됩니다.

<img src="https://github.com/user-attachments/assets/06c58fc3-8d22-450b-890c-7347fbc2456c" width="450">





