### PR TITLE
feat: 챌린지 검색 페이지

### DIFF
--- a/db.json
+++ b/db.json
@@ -26,5 +26,17 @@
       "participants": null,
       "public": true
     }
+  ],
+  "users": [
+    {
+      "id": "1",
+      "name": "홍길동",
+      "profileImageUrl": "https://image.utoimage.com/preview/cp872722/2022/12/202212008462_500.jpg"
+    },
+    {
+      "id": "2",
+      "name": "김철수",
+      "profileImageUrl": ""
+    }
   ]
 }

--- a/src/app/(pages)/challenge/_components/ChallengeCard.tsx
+++ b/src/app/(pages)/challenge/_components/ChallengeCard.tsx
@@ -27,7 +27,7 @@ export default function ChallengeCard({ challenge, userId }: { challenge: Challe
   const point = 1000;
 
   return (
-    <div className='relative min-h-[180px] rounded-2xl'>
+    <div className='relative min-h-[180px] w-full shrink-0 rounded-2xl'>
       {isOwner && <CrownFill className='absolute -top-3 right-8 z-10' />}
 
       <div className='absolute bottom-0 left-0 right-0 top-0 overflow-hidden rounded-2xl'>

--- a/src/app/(pages)/challenge/_components/ChallengeCard.tsx
+++ b/src/app/(pages)/challenge/_components/ChallengeCard.tsx
@@ -37,6 +37,8 @@ export default function ChallengeCard({ challenge, userId }: { challenge: Challe
               src={backgroundImage || challengeImage}
               alt='챌린지 이미지'
               fill
+              priority
+              sizes='(max-width: 768px) 100vw, 50vw'
               className='object-cover'
               onError={handleImageError}
             />

--- a/src/app/(pages)/challenge/_components/ChallengeList.tsx
+++ b/src/app/(pages)/challenge/_components/ChallengeList.tsx
@@ -6,7 +6,6 @@ import { CustomSession } from '@/lib/next-auth/auth';
 import { type ChallengeListType } from '@/models/challenge/Challenge';
 import ChallengeCard from './ChallengeCard';
 
-
 export default function ChallengeList({
   session,
   challengeList,

--- a/src/app/(pages)/challenge/_components/ChallengeList.tsx
+++ b/src/app/(pages)/challenge/_components/ChallengeList.tsx
@@ -6,6 +6,7 @@ import { CustomSession } from '@/lib/next-auth/auth';
 import { type ChallengeListType } from '@/models/challenge/Challenge';
 import ChallengeCard from './ChallengeCard';
 
+
 export default function ChallengeList({
   session,
   challengeList,

--- a/src/app/(pages)/challenge/_components/MissionItem.tsx
+++ b/src/app/(pages)/challenge/_components/MissionItem.tsx
@@ -28,7 +28,7 @@ export default function MissionItem({
 
   return (
     <li
-      className={`text-v1-primary-600 gap-4 rounded-2xl bg-white px-6 py-4 text-sm ${className} ${
+      className={`text-v1-primary-600 w-full shrink-0 gap-4 rounded-2xl bg-white px-6 py-4 text-sm ${className} ${
         isFinished ? 'bg-v1-text-primary-50' : 'hover:bg-[#FFF8F5] active:bg-v1-text-primary-50'
       }`}
     >

--- a/src/app/(pages)/challenge/_components/RewardItem.tsx
+++ b/src/app/(pages)/challenge/_components/RewardItem.tsx
@@ -23,7 +23,7 @@ export default function RewardItem({
 
   return (
     <li
-      className={`text-v1-primary-600 gap-4 rounded-2xl bg-white px-6 py-4 text-sm ${className} ${
+      className={`text-v1-primary-600 w-full shrink-0 gap-4 rounded-2xl bg-white px-6 py-4 text-sm ${className} ${
         reward.remain === 0 ? '!bg-v1-grey-300' : ''
       }`}
     >

--- a/src/app/(pages)/challenge/page.tsx
+++ b/src/app/(pages)/challenge/page.tsx
@@ -1,12 +1,13 @@
 import { getServerSession } from 'next-auth';
 import Link from 'next/link';
-import { Menu, Search } from 'lucide-react';
+import { Search } from 'lucide-react';
 import Header from '@/components/layout/Header';
 import PageLayout from '@/components/layout/PageLayout';
 import { CustomSession } from '@/lib/next-auth/auth';
 import { Challenge } from '@/models/challenge/Challenge';
 import BottomNav from './_components/BottomNav';
 import ChallengeList from './_components/ChallengeList';
+
 
 const Page = async ({ searchParams }: { searchParams: { page: string } }) => {
   const session = await getServerSession();

--- a/src/app/(pages)/challenge/page.tsx
+++ b/src/app/(pages)/challenge/page.tsx
@@ -1,4 +1,6 @@
 import { getServerSession } from 'next-auth';
+import Link from 'next/link';
+import { Menu, Search } from 'lucide-react';
 import Header from '@/components/layout/Header';
 import PageLayout from '@/components/layout/PageLayout';
 import { CustomSession } from '@/lib/next-auth/auth';
@@ -8,7 +10,6 @@ import ChallengeList from './_components/ChallengeList';
 
 const Page = async ({ searchParams }: { searchParams: { page: string } }) => {
   const session = await getServerSession();
-
   if (!session) {
     // TODO: 로그인 페이지로 리다이렉트
   }
@@ -24,6 +25,9 @@ const Page = async ({ searchParams }: { searchParams: { page: string } }) => {
           <Header.Item>
             <Header.BoldText bold={'작심'} text={'님의 챌린지'} />
           </Header.Item>
+          <Link href='/challenge/search'>
+            <Header.Icon Icon={Search} />
+          </Link>
         </Header>
       }
     >

--- a/src/app/(pages)/challenge/search/DynamicPage.tsx
+++ b/src/app/(pages)/challenge/search/DynamicPage.tsx
@@ -4,11 +4,13 @@ import Link from 'next/link';
 import { X } from '@/assets/images/icons';
 import Header from '@/components/layout/Header';
 import PageLayout from '@/components/layout/PageLayout';
-import { cn } from '@/lib/shadcn/utils';
+import RecentSearch from './_components/RecentSearch';
 import SearchInput from './_components/SearchInput';
+import SearchResults from './_components/SearchResults';
 import { TEMP_SEARCH_RESULT, useSearch } from './_hook/useSearch';
 
-export default function DynamicPageContent() {
+
+export default function DynamicPageContent({ searchParams }: { searchParams: { tab: string; search: string } }) {
   const {
     search,
     onSearch,
@@ -18,7 +20,9 @@ export default function DynamicPageContent() {
     deleteHistoryItem,
     addHistoryItem,
     clearAllHistory,
-  } = useSearch<typeof TEMP_SEARCH_RESULT>();
+  } = useSearch<typeof TEMP_SEARCH_RESULT>({ search: searchParams.search });
+
+  const tab = searchParams.tab || 'all';
 
   return (
     <PageLayout
@@ -30,38 +34,19 @@ export default function DynamicPageContent() {
           <Header.Center>검색</Header.Center>
         </Header>
       }
+      className='px-6 pb-10'
     >
-      <PaddingWrapper>
-        <SearchInput search={search} onSearch={onSearch} clearSearch={clearSearch} />
-      </PaddingWrapper>
+      <SearchInput search={search} onSearch={onSearch} clearSearch={clearSearch} addHistoryItem={addHistoryItem} />
 
-      <PaddingWrapper className='flex h-14 items-center justify-between'>
-        <p className='font-semibold'>최근 검색</p>
-        <button className='text-sm text-v1-text-primary-400' onClick={clearAllHistory}>
-          전체삭제
-        </button>
-      </PaddingWrapper>
-
-      <ul className='flex gap-2 overflow-x-scroll px-5 pb-2'>
-        {searchHistory.map((history) => (
-          <li key={history} className='shrink-0' onClick={() => onSearch(history)}>
-            <button className='flex h-9 items-center justify-between gap-1 rounded-2xl bg-v1-text-primary-50 px-3'>
-              <span className='text-sm text-v1-text-primary-500'>{history}</span>
-              <X className='-mr-1 scale-75' onClick={() => deleteHistoryItem(history)} />
-            </button>
-          </li>
-        ))}
-      </ul>
-
-      {searchResult.result.map((result: any) => (
-        <div key={result} onClick={() => addHistoryItem(searchResult['search'])}>
-          {searchResult['search']} : {result}
-        </div>
-      ))}
+      {tab === 'all' && !searchResult.result && (
+        <RecentSearch
+          searchHistory={searchHistory}
+          onSearch={onSearch}
+          deleteHistoryItem={deleteHistoryItem}
+          clearAllHistory={clearAllHistory}
+        />
+      )}
+      {searchResult.result && <SearchResults searchResult={searchResult} />}
     </PageLayout>
   );
-}
-
-function PaddingWrapper({ children, className }: { children: React.ReactNode; className?: string }) {
-  return <div className={cn('px-6', className)}>{children}</div>;
 }

--- a/src/app/(pages)/challenge/search/DynamicPage.tsx
+++ b/src/app/(pages)/challenge/search/DynamicPage.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import Link from 'next/link';
+import { X } from '@/assets/images/icons';
+import Header from '@/components/layout/Header';
+import PageLayout from '@/components/layout/PageLayout';
+import { cn } from '@/lib/shadcn/utils';
+import SearchInput from './_components/SearchInput';
+import { TEMP_SEARCH_RESULT, useSearch } from './_hook/useSearch';
+
+export default function DynamicPageContent() {
+  const {
+    search,
+    onSearch,
+    searchResult,
+    searchHistory,
+    clearSearch,
+    deleteHistoryItem,
+    addHistoryItem,
+    clearAllHistory,
+  } = useSearch<typeof TEMP_SEARCH_RESULT>();
+
+  return (
+    <PageLayout
+      header={
+        <Header className='border-none bg-v1-background'>
+          <Link href='.'>
+            <Header.Icon Icon={X} />
+          </Link>
+          <Header.Center>검색</Header.Center>
+        </Header>
+      }
+    >
+      <PaddingWrapper>
+        <SearchInput search={search} onSearch={onSearch} clearSearch={clearSearch} />
+      </PaddingWrapper>
+
+      <PaddingWrapper className='flex h-14 items-center justify-between'>
+        <p className='font-semibold'>최근 검색</p>
+        <button className='text-sm text-v1-text-primary-400' onClick={clearAllHistory}>
+          전체삭제
+        </button>
+      </PaddingWrapper>
+
+      <ul className='flex gap-2 overflow-x-scroll px-5 pb-2'>
+        {searchHistory.map((history) => (
+          <li key={history} className='shrink-0' onClick={() => onSearch(history)}>
+            <button className='flex h-9 items-center justify-between gap-1 rounded-2xl bg-v1-text-primary-50 px-3'>
+              <span className='text-sm text-v1-text-primary-500'>{history}</span>
+              <X className='-mr-1 scale-75' onClick={() => deleteHistoryItem(history)} />
+            </button>
+          </li>
+        ))}
+      </ul>
+
+      {searchResult.result.map((result: any) => (
+        <div key={result} onClick={() => addHistoryItem(searchResult['search'])}>
+          {searchResult['search']} : {result}
+        </div>
+      ))}
+    </PageLayout>
+  );
+}
+
+function PaddingWrapper({ children, className }: { children: React.ReactNode; className?: string }) {
+  return <div className={cn('px-6', className)}>{children}</div>;
+}

--- a/src/app/(pages)/challenge/search/DynamicPage.tsx
+++ b/src/app/(pages)/challenge/search/DynamicPage.tsx
@@ -20,6 +20,7 @@ export default function DynamicPageContent({ searchParams }: { searchParams: { t
     deleteHistoryItem,
     addHistoryItem,
     clearAllHistory,
+    handleHistoryClick,
   } = useSearch<typeof TEMP_SEARCH_RESULT>({ search: searchParams.search });
 
   const tab = searchParams.tab || 'all';
@@ -38,12 +39,12 @@ export default function DynamicPageContent({ searchParams }: { searchParams: { t
     >
       <SearchInput search={search} onSearch={onSearch} clearSearch={clearSearch} addHistoryItem={addHistoryItem} />
 
-      {tab === 'all' && !searchResult.result && (
+      {tab === 'all' && !searchResult.result && searchHistory.length > 0 && (
         <RecentSearch
           searchHistory={searchHistory}
-          onSearch={onSearch}
           deleteHistoryItem={deleteHistoryItem}
           clearAllHistory={clearAllHistory}
+          handleHistoryClick={handleHistoryClick}
         />
       )}
       {searchResult.result && <SearchResults searchResult={searchResult} />}

--- a/src/app/(pages)/challenge/search/_components/HorizontalScrollList.tsx
+++ b/src/app/(pages)/challenge/search/_components/HorizontalScrollList.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 export default function HorizontalScrollList({
   children,
   className,
@@ -5,5 +7,41 @@ export default function HorizontalScrollList({
   children: React.ReactNode;
   className?: string;
 }) {
-  return <ul className={`-mx-6 flex gap-2 overflow-x-scroll px-6 pb-2 ${className}`}>{children}</ul>;
+  const [isDragging, setIsDragging] = React.useState(false);
+  const [startX, setStartX] = React.useState(0);
+  const [scrollLeft, setScrollLeft] = React.useState(0);
+  const scrollRef = React.useRef<HTMLUListElement>(null);
+
+  const handleMouseDown = (e: React.MouseEvent) => {
+    setIsDragging(true);
+    setStartX(e.pageX - (scrollRef.current?.offsetLeft || 0));
+    setScrollLeft(scrollRef.current?.scrollLeft || 0);
+  };
+
+  const handleMouseMove = (e: React.MouseEvent) => {
+    if (!isDragging) return;
+    e.preventDefault();
+    const x = e.pageX - (scrollRef.current?.offsetLeft || 0);
+    const walk = (x - startX) * 1.5;
+    if (scrollRef.current) {
+      scrollRef.current.scrollLeft = scrollLeft - walk;
+    }
+  };
+
+  const handleMouseUp = () => {
+    setIsDragging(false);
+  };
+
+  return (
+    <ul
+      ref={scrollRef}
+      className={`scrollbar-hide -mx-6 flex cursor-grab select-none gap-2 overflow-x-scroll px-6 pb-2 active:cursor-grabbing ${className}`}
+      onMouseDown={handleMouseDown}
+      onMouseMove={handleMouseMove}
+      onMouseUp={handleMouseUp}
+      onMouseLeave={handleMouseUp}
+    >
+      {children}
+    </ul>
+  );
 }

--- a/src/app/(pages)/challenge/search/_components/HorizontalScrollList.tsx
+++ b/src/app/(pages)/challenge/search/_components/HorizontalScrollList.tsx
@@ -1,0 +1,9 @@
+export default function HorizontalScrollList({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return <ul className={`-mx-6 flex gap-2 overflow-x-scroll px-6 pb-2 ${className}`}>{children}</ul>;
+}

--- a/src/app/(pages)/challenge/search/_components/MoreButton.tsx
+++ b/src/app/(pages)/challenge/search/_components/MoreButton.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
+import { ChevronRight } from '@/assets/images/icons';
+import { TabType } from './SearchResults';
+
+export default function MoreButton({ tab }: { tab: TabType }) {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  const handleClick = () => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('tab', tab);
+    router.push(`?${params.toString()}`);
+  };
+
+  return (
+    <button onClick={handleClick} className='flex items-center text-sm text-v1-text-primary-300'>
+      더보기
+      <ChevronRight className='-ml-[3px] scale-75 opacity-50' />
+    </button>
+  );
+}

--- a/src/app/(pages)/challenge/search/_components/RecentSearch.tsx
+++ b/src/app/(pages)/challenge/search/_components/RecentSearch.tsx
@@ -1,0 +1,38 @@
+import { X } from 'lucide-react';
+import { useSearch } from '../_hook/useSearch';
+import HorizontalScrollList from './HorizontalScrollList';
+
+interface RecentSearchProps {
+  searchHistory: ReturnType<typeof useSearch>['searchHistory'];
+  onSearch: ReturnType<typeof useSearch>['onSearch'];
+  deleteHistoryItem: ReturnType<typeof useSearch>['deleteHistoryItem'];
+  clearAllHistory: ReturnType<typeof useSearch>['clearAllHistory'];
+}
+
+export default function RecentSearch({
+  searchHistory,
+  onSearch,
+  deleteHistoryItem,
+  clearAllHistory,
+}: RecentSearchProps) {
+  return (
+    <>
+      <div className='flex h-10 items-center justify-between'>
+        <p className='font-semibold'>최근 검색</p>
+        <button className='h-full px-2 text-sm text-v1-text-primary-400' onClick={clearAllHistory}>
+          전체삭제
+        </button>
+      </div>
+      <HorizontalScrollList className='pt-0'>
+        {searchHistory.map((history) => (
+          <li key={history} className='shrink-0' onClick={() => onSearch(history)}>
+            <button className='flex h-9 items-center justify-between gap-1 rounded-2xl bg-v1-text-primary-50 px-3'>
+              <span className='text-sm text-v1-text-primary-500'>{history}</span>
+              <X className='-mr-1 scale-75' onClick={() => deleteHistoryItem(history)} />
+            </button>
+          </li>
+        ))}
+      </HorizontalScrollList>
+    </>
+  );
+}

--- a/src/app/(pages)/challenge/search/_components/RecentSearch.tsx
+++ b/src/app/(pages)/challenge/search/_components/RecentSearch.tsx
@@ -2,16 +2,17 @@ import { X } from 'lucide-react';
 import { useSearch } from '../_hook/useSearch';
 import HorizontalScrollList from './HorizontalScrollList';
 
+
 interface RecentSearchProps {
   searchHistory: ReturnType<typeof useSearch>['searchHistory'];
-  onSearch: ReturnType<typeof useSearch>['onSearch'];
+  handleHistoryClick: ReturnType<typeof useSearch>['handleHistoryClick'];
   deleteHistoryItem: ReturnType<typeof useSearch>['deleteHistoryItem'];
   clearAllHistory: ReturnType<typeof useSearch>['clearAllHistory'];
 }
 
 export default function RecentSearch({
   searchHistory,
-  onSearch,
+  handleHistoryClick,
   deleteHistoryItem,
   clearAllHistory,
 }: RecentSearchProps) {
@@ -25,10 +26,18 @@ export default function RecentSearch({
       </div>
       <HorizontalScrollList className='pt-0'>
         {searchHistory.map((history) => (
-          <li key={history} className='shrink-0' onClick={() => onSearch(history)}>
+          <li key={history} className='shrink-0' onClick={() => handleHistoryClick(history)}>
             <button className='flex h-9 items-center justify-between gap-1 rounded-2xl bg-v1-text-primary-50 px-3'>
               <span className='text-sm text-v1-text-primary-500'>{history}</span>
-              <X className='-mr-1 scale-75' onClick={() => deleteHistoryItem(history)} />
+              <div
+                className='-mr-1 flex h-full items-center justify-center'
+                onClick={(e) => {
+                  e.stopPropagation();
+                  deleteHistoryItem(history);
+                }}
+              >
+                <X className='scale-75' />
+              </div>
             </button>
           </li>
         ))}

--- a/src/app/(pages)/challenge/search/_components/SearchInput.tsx
+++ b/src/app/(pages)/challenge/search/_components/SearchInput.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+import { Search, X } from '@/assets/images/icons';
+import InputWithError from '@/components/input/InputWithErrorMsg';
+import { useSearch } from '../_hook/useSearch';
+
+interface SearchFormProps {
+  onSearch: ReturnType<typeof useSearch>['onSearch'];
+  search: ReturnType<typeof useSearch>['search'];
+  clearSearch: ReturnType<typeof useSearch>['clearSearch'];
+}
+
+const DELAY = 200;
+
+export default function SearchInput({ onSearch, search, clearSearch }: SearchFormProps) {
+  const [searchTimeout, setSearchTimeout] = useState<NodeJS.Timeout>();
+  const [currentSearch, setCurrentSearch] = useState(search);
+
+  useEffect(() => {
+    if (currentSearch) {
+      if (searchTimeout) {
+        clearTimeout(searchTimeout);
+      }
+      setSearchTimeout(setTimeout(() => onSearch(currentSearch), DELAY));
+    }
+  }, [currentSearch]);
+
+  useEffect(() => {
+    setCurrentSearch(search);
+  }, [search]);
+
+  const handleClearSearch = () => {
+    setCurrentSearch('');
+    clearSearch();
+  };
+
+  return (
+    <div className='relative mt-2 h-16'>
+      {!currentSearch && <Search className='absolute left-6 top-3 mt-[1px]' />}
+      <InputWithError
+        placeholder='검색어를 입력해주세요'
+        value={currentSearch}
+        onChange={(e) => setCurrentSearch(e.target.value)}
+        autoComplete='off'
+        style={{ paddingLeft: !currentSearch ? '3.5rem' : '2rem' }}
+        hasError={false}
+      />
+      {currentSearch && <X className='absolute right-6 top-3 mt-[1px]' onClick={handleClearSearch} />}
+    </div>
+  );
+}

--- a/src/app/(pages)/challenge/search/_components/SearchInput.tsx
+++ b/src/app/(pages)/challenge/search/_components/SearchInput.tsx
@@ -3,15 +3,17 @@ import { Search, X } from '@/assets/images/icons';
 import InputWithError from '@/components/input/InputWithErrorMsg';
 import { useSearch } from '../_hook/useSearch';
 
+
 interface SearchFormProps {
   onSearch: ReturnType<typeof useSearch>['onSearch'];
   search: ReturnType<typeof useSearch>['search'];
   clearSearch: ReturnType<typeof useSearch>['clearSearch'];
+  addHistoryItem: ReturnType<typeof useSearch>['addHistoryItem'];
 }
 
 const DELAY = 200;
 
-export default function SearchInput({ onSearch, search, clearSearch }: SearchFormProps) {
+export default function SearchInput({ onSearch, search, clearSearch, addHistoryItem }: SearchFormProps) {
   const [searchTimeout, setSearchTimeout] = useState<NodeJS.Timeout>();
   const [currentSearch, setCurrentSearch] = useState(search);
 
@@ -22,7 +24,8 @@ export default function SearchInput({ onSearch, search, clearSearch }: SearchFor
       }
       setSearchTimeout(setTimeout(() => onSearch(currentSearch), DELAY));
     }
-  }, [currentSearch]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentSearch, onSearch]);
 
   useEffect(() => {
     setCurrentSearch(search);
@@ -43,6 +46,11 @@ export default function SearchInput({ onSearch, search, clearSearch }: SearchFor
         autoComplete='off'
         style={{ paddingLeft: !currentSearch ? '3.5rem' : '2rem' }}
         hasError={false}
+        onBlur={() => {
+          if (currentSearch) {
+            addHistoryItem(currentSearch);
+          }
+        }}
       />
       {currentSearch && <X className='absolute right-6 top-3 mt-[1px]' onClick={handleClearSearch} />}
     </div>

--- a/src/app/(pages)/challenge/search/_components/SearchInput.tsx
+++ b/src/app/(pages)/challenge/search/_components/SearchInput.tsx
@@ -18,23 +18,21 @@ export default function SearchInput({ onSearch, search, clearSearch, addHistoryI
   const [currentSearch, setCurrentSearch] = useState(search);
 
   useEffect(() => {
-    if (currentSearch) {
-      if (searchTimeout) {
-        clearTimeout(searchTimeout);
-      }
-      setSearchTimeout(setTimeout(() => onSearch(currentSearch), DELAY));
+    if (searchTimeout) {
+      clearTimeout(searchTimeout);
     }
+    setSearchTimeout(setTimeout(() => onSearch(currentSearch), DELAY));
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentSearch, onSearch]);
-
-  useEffect(() => {
-    setCurrentSearch(search);
-  }, [search]);
+  }, [currentSearch]);
 
   const handleClearSearch = () => {
     setCurrentSearch('');
     clearSearch();
   };
+
+  useEffect(() => {
+    setCurrentSearch(search);
+  }, [search]);
 
   return (
     <div className='relative mt-2 h-16'>

--- a/src/app/(pages)/challenge/search/_components/SearchResults.tsx
+++ b/src/app/(pages)/challenge/search/_components/SearchResults.tsx
@@ -29,7 +29,7 @@ export default function SearchResults({ searchResult }: SearchResultsProps) {
 
   return (
     <>
-      <LinkTabs tab={tab} tabs={TABS} className={!isAll ? 'mb-4' : ''} />
+      <LinkTabs tab={tab} tabs={TABS} className={`px-4 ${!isAll ? 'mb-4' : ''}`} />
       {isAll && <SectionHeader title='대화 상대' tab='user' />}
       {isAll || tab === 'user' ? (
         <HorizontalScrollList>

--- a/src/app/(pages)/challenge/search/_components/SearchResults.tsx
+++ b/src/app/(pages)/challenge/search/_components/SearchResults.tsx
@@ -1,0 +1,68 @@
+import { useSearchParams } from 'next/navigation';
+import LinkTabs from '@/components/tab/LinkTabs';
+import ChallengeCard from '../../_components/ChallengeCard';
+import MissionItem from '../../_components/MissionItem';
+import RewardItem from '../../_components/RewardItem';
+import { TEMP_SEARCH_RESULT, useSearch } from '../_hook/useSearch';
+import HorizontalScrollList from './HorizontalScrollList';
+import SectionHeader from './SectionHeader';
+import UserItem from './UserItem';
+
+const DUMMY_USER_ID = '75ab190b-6998-41c5-98d2-ea70df102264';
+const TABS = [
+  { type: 'all', label: '전체', href: '?tab=all' },
+  { type: 'user', label: '대화상대', href: '?tab=user' },
+  { type: 'challenge', label: '챌린지', href: '?tab=challenge' },
+  { type: 'mission', label: '미션', href: '?tab=mission' },
+  { type: 'reward', label: '리워드(보상)', href: '?tab=reward' },
+];
+export type TabType = (typeof TABS)[number]['type'];
+
+interface SearchResultsProps {
+  searchResult: ReturnType<typeof useSearch<typeof TEMP_SEARCH_RESULT>>['searchResult'];
+}
+
+export default function SearchResults({ searchResult }: SearchResultsProps) {
+  const searchParams = useSearchParams();
+  const tab = searchParams.get('tab') || 'all';
+  const isAll = tab === 'all';
+
+  return (
+    <>
+      <LinkTabs tab={tab} tabs={TABS} className={!isAll ? 'mb-4' : ''} />
+      {isAll && <SectionHeader title='대화 상대' tab='user' />}
+      {isAll || tab === 'user' ? (
+        <HorizontalScrollList>
+          {searchResult.result?.users.map((user) => <UserItem user={user} key={user.id} />)}
+        </HorizontalScrollList>
+      ) : null}
+
+      {isAll && <SectionHeader title='챌린지' tab='challenge' />}
+      {isAll || tab === 'challenge' ? (
+        <HorizontalScrollList>
+          {searchResult.result?.challenges.map((challenge) => (
+            <ChallengeCard key={challenge.challengeId} challenge={challenge} userId={DUMMY_USER_ID} />
+          ))}
+        </HorizontalScrollList>
+      ) : null}
+
+      {isAll && <SectionHeader title='미션' tab='mission' />}
+      {isAll || tab === 'mission' ? (
+        <HorizontalScrollList>
+          {searchResult.result?.missions.map((mission) => (
+            <MissionItem key={mission.id} mission={mission} hasFavorite={true} />
+          ))}
+        </HorizontalScrollList>
+      ) : null}
+
+      {isAll && <SectionHeader title='리워드(보상)' tab='reward' />}
+      {isAll || tab === 'reward' ? (
+        <HorizontalScrollList>
+          {searchResult.result?.rewards.map((reward) => (
+            <RewardItem key={reward.id} reward={reward} hasFavorite={true} />
+          ))}
+        </HorizontalScrollList>
+      ) : null}
+    </>
+  );
+}

--- a/src/app/(pages)/challenge/search/_components/SectionHeader.tsx
+++ b/src/app/(pages)/challenge/search/_components/SectionHeader.tsx
@@ -1,0 +1,11 @@
+import MoreButton from './MoreButton';
+import { TabType } from './SearchResults';
+
+export default function SectionHeader({ title, tab }: { title: string; tab: TabType }) {
+  return (
+    <div className='flex h-14 items-center justify-between'>
+      <p className='font-semibold'>{title}</p>
+      <MoreButton tab={tab} />
+    </div>
+  );
+}

--- a/src/app/(pages)/challenge/search/_components/UserItem.tsx
+++ b/src/app/(pages)/challenge/search/_components/UserItem.tsx
@@ -1,0 +1,24 @@
+import Image from 'next/image';
+import defaultImage from '@/assets/images/placeholder/face-default.png';
+import Button from '@/components/button/Button';
+import { User } from '@/types/challenge';
+
+export default function UserItem({ user }: { user: User }) {
+  return (
+    <div className='flex h-[232px] w-full shrink-0 flex-col items-center justify-between gap-2 rounded-3xl bg-white px-6 py-6'>
+      <div className='flex flex-col items-center justify-center gap-2'>
+        <Image
+          src={user.profileImageUrl || defaultImage}
+          alt={user.name}
+          width={84}
+          height={84}
+          className='h-[84px] w-[84px] rounded-full object-cover'
+        />
+        <p className='font-semibold'>{user.name}</p>
+      </div>
+      <Button size='md' className='max-w-[250px]'>
+        채팅 하러가기
+      </Button>
+    </div>
+  );
+}

--- a/src/app/(pages)/challenge/search/_hook/useSearch.test.tsx
+++ b/src/app/(pages)/challenge/search/_hook/useSearch.test.tsx
@@ -1,78 +1,103 @@
+import { useRouter, useSearchParams } from 'next/navigation';
 import { act, renderHook } from '@testing-library/react';
-import { useSearch } from './useSearch';
+import { TEMP_SEARCH_RESULT, useSearch } from './useSearch';
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+  useSearchParams: jest.fn(),
+}));
 
 describe('useSearch 커스텀훅 테스트', () => {
+  const mockRouterPush = jest.fn();
+  const mockSearchParams = new URLSearchParams();
+  let result: {
+    current: ReturnType<typeof useSearch<typeof TEMP_SEARCH_RESULT>>;
+  };
+
   beforeEach(() => {
-    window.localStorage.clear();
+    (useRouter as jest.Mock).mockReturnValue({
+      push: mockRouterPush,
+    });
+    (useSearchParams as jest.Mock).mockReturnValue(mockSearchParams);
+    localStorage.clear();
+    result = renderHook(() => useSearch<typeof TEMP_SEARCH_RESULT>({ search: '' })).result;
   });
 
-  it('검색을 수행하고, 검색결과에 반영', () => {
-    const { result } = renderHook(() => useSearch());
-
-    act(() => {
-      result.current.setSearch('입력한 검색어');
-      result.current.setSearchResult({ search: '입력한 검색어', result: ['검색-결과-1'] });
+  describe('검색 기능', () => {
+    it('초기 검색 값을 설정합니다.', () => {
+      result = renderHook(() => useSearch<typeof TEMP_SEARCH_RESULT>({ search: 'initial' })).result;
+      expect(result.current.search).toBe('initial');
     });
 
-    expect(result.current.search).toBe('입력한 검색어');
-    expect(result.current.searchResult.search).toBe('입력한 검색어');
+    it('onSearch 호출 시 searchResult와 URL을 업데이트합니다.', () => {
+      act(() => {
+        result.current.onSearch('newSearch');
+      });
+
+      expect(result.current.searchResult.search).toBe('newSearch');
+      expect(result.current.searchResult.result).toBeDefined();
+      expect(mockRouterPush).toHaveBeenCalledWith('?search=newSearch');
+    });
+
+    it('검색 취소 시, 검색상태와 검색결과를 초기화합니다.', () => {
+      act(() => {
+        result.current.setSearch('입력한 검색어');
+        result.current.setSearchResult({ search: '입력한 검색어', result: TEMP_SEARCH_RESULT });
+        result.current.clearSearch();
+      });
+
+      expect(result.current.search).toBe('');
+      expect(result.current.searchResult).toEqual({ search: '', result: undefined });
+    });
   });
 
-  it('검색 취소 시, 검색상태와 검색결과를 초기화', () => {
-    const { result } = renderHook(() => useSearch());
+  describe('검색 기록 관리', () => {
+    it('검색 기록을 추가합니다.', () => {
+      act(() => {
+        result.current.addHistoryItem('newSearch');
+      });
 
-    act(() => {
-      result.current.setSearch('입력한 검색어');
-      result.current.setSearchResult({ search: '입력한 검색어', result: ['검색-결과-1'] });
-      result.current.clearSearch();
+      expect(result.current.searchHistory).toContain('newSearch');
+      expect(localStorage.getItem('searchHistory')).toContain('newSearch');
     });
 
-    expect(result.current.search).toBe('');
-    expect(result.current.searchResult).toEqual({ search: '', result: [] });
-  });
+    it('검색 기록 중복 추가를 방지합니다.', () => {
+      act(() => {
+        result.current.addHistoryItem('newSearch');
+        result.current.addHistoryItem('newSearch');
+      });
 
-  it('최근검색 항목 클릭시, 검색이 수행되어야 함', () => {
-    const { result } = renderHook(() => useSearch());
-
-    act(() => {
-      result.current.handleHistoryClick('검색어 기록1');
+      expect(result.current.searchHistory).toEqual(['newSearch']);
     });
 
-    expect(result.current.search).toBe('검색어 기록1');
-    expect(result.current.searchResult.search).toBe('검색어 기록1');
-  });
+    it('최근검색 항목 클릭시, 검색이 수행되어야 합니다.', () => {
+      act(() => {
+        result.current.handleHistoryClick('검색어 기록1');
+      });
 
-  it('최근검색 항목 추가', () => {
-    const { result } = renderHook(() => useSearch());
-
-    act(() => {
-      result.current.addHistoryItem('검색어 기록1');
+      expect(result.current.search).toBe('검색어 기록1');
+      expect(result.current.searchResult.search).toBe('검색어 기록1');
     });
 
-    expect(result.current.searchHistory).toContain('검색어 기록1');
-  });
+    it('단일 검색기록 항목을 삭제합니다.', () => {
+      const initialHistory = ['item1', 'item2', 'item3'];
 
-  it('단일 검색기록 항목을 삭제', () => {
-    const { result } = renderHook(() => useSearch());
-    const initialHistory = ['item1', 'item2', 'item3'];
+      act(() => {
+        result.current.clearAllHistory();
+        result.current.setSearchHistory(initialHistory);
+        result.current.deleteHistoryItem('item2');
+      });
 
-    act(() => {
-      result.current.clearAllHistory();
-      result.current.setSearchHistory(initialHistory);
-      result.current.deleteHistoryItem('item2');
+      expect(result.current.searchHistory).not.toContain('item2');
     });
 
-    expect(result.current.searchHistory).not.toContain('item2');
-  });
+    it('모든 검색기록 항목을 삭제합니다.', () => {
+      act(() => {
+        result.current.clearAllHistory();
+      });
 
-  it('모든 검색기록 항목을 삭제', () => {
-    const { result } = renderHook(() => useSearch());
-
-    act(() => {
-      result.current.clearAllHistory();
+      expect(result.current.searchHistory).toHaveLength(0);
+      expect(localStorage.getItem('searchHistory')).toBe('[]');
     });
-
-    expect(result.current.searchHistory).toHaveLength(0);
-    expect(localStorage.getItem('searchHistory')).toBe('[]');
   });
 });

--- a/src/app/(pages)/challenge/search/_hook/useSearch.test.tsx
+++ b/src/app/(pages)/challenge/search/_hook/useSearch.test.tsx
@@ -1,0 +1,78 @@
+import { act, renderHook } from '@testing-library/react';
+import { useSearch } from './useSearch';
+
+describe('useSearch 커스텀훅 테스트', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('검색을 수행하고, 검색결과에 반영', () => {
+    const { result } = renderHook(() => useSearch());
+
+    act(() => {
+      result.current.setSearch('입력한 검색어');
+      result.current.setSearchResult({ search: '입력한 검색어', result: ['검색-결과-1'] });
+    });
+
+    expect(result.current.search).toBe('입력한 검색어');
+    expect(result.current.searchResult.search).toBe('입력한 검색어');
+  });
+
+  it('검색 취소 시, 검색상태와 검색결과를 초기화', () => {
+    const { result } = renderHook(() => useSearch());
+
+    act(() => {
+      result.current.setSearch('입력한 검색어');
+      result.current.setSearchResult({ search: '입력한 검색어', result: ['검색-결과-1'] });
+      result.current.clearSearch();
+    });
+
+    expect(result.current.search).toBe('');
+    expect(result.current.searchResult).toEqual({ search: '', result: [] });
+  });
+
+  it('최근검색 항목 클릭시, 검색이 수행되어야 함', () => {
+    const { result } = renderHook(() => useSearch());
+
+    act(() => {
+      result.current.handleHistoryClick('검색어 기록1');
+    });
+
+    expect(result.current.search).toBe('검색어 기록1');
+    expect(result.current.searchResult.search).toBe('검색어 기록1');
+  });
+
+  it('최근검색 항목 추가', () => {
+    const { result } = renderHook(() => useSearch());
+
+    act(() => {
+      result.current.addHistoryItem('검색어 기록1');
+    });
+
+    expect(result.current.searchHistory).toContain('검색어 기록1');
+  });
+
+  it('단일 검색기록 항목을 삭제', () => {
+    const { result } = renderHook(() => useSearch());
+    const initialHistory = ['item1', 'item2', 'item3'];
+
+    act(() => {
+      result.current.clearAllHistory();
+      result.current.setSearchHistory(initialHistory);
+      result.current.deleteHistoryItem('item2');
+    });
+
+    expect(result.current.searchHistory).not.toContain('item2');
+  });
+
+  it('모든 검색기록 항목을 삭제', () => {
+    const { result } = renderHook(() => useSearch());
+
+    act(() => {
+      result.current.clearAllHistory();
+    });
+
+    expect(result.current.searchHistory).toHaveLength(0);
+    expect(localStorage.getItem('searchHistory')).toBe('[]');
+  });
+});

--- a/src/app/(pages)/challenge/search/_hook/useSearch.test.tsx
+++ b/src/app/(pages)/challenge/search/_hook/useSearch.test.tsx
@@ -72,7 +72,7 @@ describe('useSearch 커스텀훅 테스트', () => {
       });
 
       expect(result.current.searchHistory).toContain('newSearch');
-      expect(localStorage.getItem('searchHistory')).toContain('newSearch');
+      expect(localStorage.getItem('search-history')).toContain('newSearch');
     });
 
     it('검색 기록 중복 추가를 방지합니다.', () => {
@@ -111,7 +111,7 @@ describe('useSearch 커스텀훅 테스트', () => {
       });
 
       expect(result.current.searchHistory).toHaveLength(0);
-      expect(localStorage.getItem('searchHistory')).toBe('[]');
+      expect(localStorage.getItem('search-history')).toBe('[]');
     });
   });
 });

--- a/src/app/(pages)/challenge/search/_hook/useSearch.test.tsx
+++ b/src/app/(pages)/challenge/search/_hook/useSearch.test.tsx
@@ -49,6 +49,20 @@ describe('useSearch 커스텀훅 테스트', () => {
       expect(result.current.search).toBe('');
       expect(result.current.searchResult).toEqual({ search: '', result: undefined });
     });
+
+    it('검색어가 없을 때 URL에서 search 파라미터를 제거합니다.', () => {
+      // 먼저 검색어로 URL 설정
+      act(() => {
+        result.current.onSearch('someSearch');
+      });
+      expect(mockRouterPush).toHaveBeenLastCalledWith('?search=someSearch');
+
+      // 검색어를 지우면 search 파라미터가 제거됨
+      act(() => {
+        result.current.onSearch('');
+      });
+      expect(mockRouterPush).toHaveBeenLastCalledWith('?');
+    });
   });
 
   describe('검색 기록 관리', () => {

--- a/src/app/(pages)/challenge/search/_hook/useSearch.ts
+++ b/src/app/(pages)/challenge/search/_hook/useSearch.ts
@@ -1,32 +1,53 @@
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import db from '@/../db.json';
+import dummyMission from '../../_mock/dummyMission.json';
+import dummyReward from '../../_mock/dummyReward.json';
 
-const TEMP_SEARCH_HISTORY = ['검색어1', '검색어2', '검색어3', '검색어4', '검색어5'];
-export const TEMP_SEARCH_RESULT = ['검색결과1'];
+export const TEMP_SEARCH_RESULT = {
+  users: db.users,
+  challenges: db.challenge,
+  missions: dummyMission,
+  rewards: dummyReward,
+};
 
 const MAX_SEARCH_HISTORY = 10;
 
-export function useSearch<T>() {
-  const [search, setSearch] = useState('');
-  const [searchResult, setSearchResult] = useState<{ search: string; result: T[] }>({ search: '', result: [] });
+export function useSearch<T>({ search: initialSearch }: { search: string }) {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  const [search, setSearch] = useState(initialSearch);
+  const [searchResult, setSearchResult] = useState<{ search: string; result: T | undefined }>({
+    search: '',
+    result: undefined,
+  });
   const [searchHistory, setSearchHistory] = useState<string[]>(() => {
     if (typeof window !== 'undefined') {
       const saved = localStorage.getItem('searchHistory');
-      return saved ? JSON.parse(saved) : TEMP_SEARCH_HISTORY;
+      return saved ? JSON.parse(saved) : [];
     }
-    return TEMP_SEARCH_HISTORY;
+    return [];
   });
 
-  const onSearch = (search: string) => {
-    const result = {
-      search,
-      result: TEMP_SEARCH_RESULT as T[],
-    };
-    setSearchResult(result);
-  };
+  const onSearch = useCallback(
+    (search: string) => {
+      const result = {
+        search,
+        result: TEMP_SEARCH_RESULT as unknown as T,
+      };
+      setSearchResult(result);
+
+      const params = new URLSearchParams(searchParams.toString());
+      params.set('search', search);
+      router.push(`?${params.toString()}`);
+    },
+    [router, searchParams],
+  );
 
   const clearSearch = () => {
     setSearch('');
-    setSearchResult({ search: '', result: [] });
+    setSearchResult({ search: '', result: undefined });
   };
 
   const handleHistoryClick = (historyItem: string) => {
@@ -52,6 +73,12 @@ export function useSearch<T>() {
     setSearchHistory([]);
     localStorage.setItem('searchHistory', '[]');
   };
+
+  useEffect(() => {
+    if (initialSearch) {
+      onSearch(initialSearch);
+    }
+  }, [initialSearch, onSearch]);
 
   return {
     search,

--- a/src/app/(pages)/challenge/search/_hook/useSearch.ts
+++ b/src/app/(pages)/challenge/search/_hook/useSearch.ts
@@ -63,19 +63,19 @@ export function useSearch<T>({ search: initialSearch }: { search: string }) {
     if (!searchHistory.includes(item)) {
       const newHistory = [item, ...searchHistory].slice(0, MAX_SEARCH_HISTORY);
       setSearchHistory(newHistory);
-      localStorage.setItem('searchHistory', JSON.stringify(newHistory));
+      localStorage.setItem('search-history', JSON.stringify(newHistory));
     }
   };
 
   const deleteHistoryItem = (item: string) => {
     const newHistory = searchHistory.filter((h) => h !== item);
     setSearchHistory(newHistory);
-    localStorage.setItem('searchHistory', JSON.stringify(newHistory));
+    localStorage.setItem('search-history', JSON.stringify(newHistory));
   };
 
   const clearAllHistory = () => {
     setSearchHistory([]);
-    localStorage.setItem('searchHistory', '[]');
+    localStorage.setItem('search-history', '[]');
   };
 
   useEffect(() => {
@@ -85,10 +85,9 @@ export function useSearch<T>({ search: initialSearch }: { search: string }) {
   }, [initialSearch, onSearch]);
 
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const saved = localStorage.getItem('search-history');
-      setSearchHistory(saved ? JSON.parse(saved) : []);
-    }
+    const saved = localStorage.getItem('search-history');
+    console.log('saved', saved);
+    setSearchHistory(saved ? JSON.parse(saved) : []);
   }, []);
 
   return {

--- a/src/app/(pages)/challenge/search/_hook/useSearch.ts
+++ b/src/app/(pages)/challenge/search/_hook/useSearch.ts
@@ -4,6 +4,7 @@ import db from '@/../db.json';
 import dummyMission from '../../_mock/dummyMission.json';
 import dummyReward from '../../_mock/dummyReward.json';
 
+
 export const TEMP_SEARCH_RESULT = {
   users: db.users,
   challenges: db.challenge,
@@ -22,26 +23,29 @@ export function useSearch<T>({ search: initialSearch }: { search: string }) {
     search: '',
     result: undefined,
   });
-  const [searchHistory, setSearchHistory] = useState<string[]>(() => {
-    if (typeof window !== 'undefined') {
-      const saved = localStorage.getItem('searchHistory');
-      return saved ? JSON.parse(saved) : [];
-    }
-    return [];
-  });
+  const [searchHistory, setSearchHistory] = useState<string[]>([]);
 
   const onSearch = useCallback(
     (search: string) => {
-      const result = {
-        search,
-        result: TEMP_SEARCH_RESULT as unknown as T,
-      };
-      setSearchResult(result);
-
       const params = new URLSearchParams(searchParams.toString());
-      params.set('search', search);
+      if (search) {
+        params.set('search', search);
+      } else {
+        params.delete('search');
+        clearSearch();
+      }
+
+      if (search && search !== searchResult.search) {
+        const result = {
+          search,
+          result: TEMP_SEARCH_RESULT as unknown as T,
+        };
+        setSearchResult(result);
+      }
+
       router.push(`?${params.toString()}`);
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [router, searchParams],
   );
 
@@ -79,6 +83,13 @@ export function useSearch<T>({ search: initialSearch }: { search: string }) {
       onSearch(initialSearch);
     }
   }, [initialSearch, onSearch]);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const saved = localStorage.getItem('search-history');
+      setSearchHistory(saved ? JSON.parse(saved) : []);
+    }
+  }, []);
 
   return {
     search,

--- a/src/app/(pages)/challenge/search/_hook/useSearch.ts
+++ b/src/app/(pages)/challenge/search/_hook/useSearch.ts
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+
+const TEMP_SEARCH_HISTORY = ['검색어1', '검색어2', '검색어3', '검색어4', '검색어5'];
+export const TEMP_SEARCH_RESULT = ['검색결과1'];
+
+const MAX_SEARCH_HISTORY = 10;
+
+export function useSearch<T>() {
+  const [search, setSearch] = useState('');
+  const [searchResult, setSearchResult] = useState<{ search: string; result: T[] }>({ search: '', result: [] });
+  const [searchHistory, setSearchHistory] = useState<string[]>(() => {
+    if (typeof window !== 'undefined') {
+      const saved = localStorage.getItem('searchHistory');
+      return saved ? JSON.parse(saved) : TEMP_SEARCH_HISTORY;
+    }
+    return TEMP_SEARCH_HISTORY;
+  });
+
+  const onSearch = (search: string) => {
+    const result = {
+      search,
+      result: TEMP_SEARCH_RESULT as T[],
+    };
+    setSearchResult(result);
+  };
+
+  const clearSearch = () => {
+    setSearch('');
+    setSearchResult({ search: '', result: [] });
+  };
+
+  const handleHistoryClick = (historyItem: string) => {
+    setSearch(historyItem);
+    onSearch(historyItem);
+  };
+
+  const addHistoryItem = (item: string) => {
+    if (!searchHistory.includes(item)) {
+      const newHistory = [item, ...searchHistory].slice(0, MAX_SEARCH_HISTORY);
+      setSearchHistory(newHistory);
+      localStorage.setItem('searchHistory', JSON.stringify(newHistory));
+    }
+  };
+
+  const deleteHistoryItem = (item: string) => {
+    const newHistory = searchHistory.filter((h) => h !== item);
+    setSearchHistory(newHistory);
+    localStorage.setItem('searchHistory', JSON.stringify(newHistory));
+  };
+
+  const clearAllHistory = () => {
+    setSearchHistory([]);
+    localStorage.setItem('searchHistory', '[]');
+  };
+
+  return {
+    search,
+    setSearch,
+    onSearch,
+    searchResult,
+    setSearchResult,
+    searchHistory,
+    setSearchHistory,
+    clearSearch,
+    handleHistoryClick,
+    addHistoryItem,
+    deleteHistoryItem,
+    clearAllHistory,
+  };
+}

--- a/src/app/(pages)/challenge/search/page.tsx
+++ b/src/app/(pages)/challenge/search/page.tsx
@@ -4,6 +4,6 @@ const DynamicPage = dynamic(() => import('./DynamicPage'), {
   ssr: false,
 });
 
-export default function Page() {
-  return <DynamicPage />;
+export default function Page({ searchParams }: { searchParams: { tab: string; search: string } }) {
+  return <DynamicPage searchParams={searchParams} />;
 }

--- a/src/app/(pages)/challenge/search/page.tsx
+++ b/src/app/(pages)/challenge/search/page.tsx
@@ -1,0 +1,9 @@
+import dynamic from 'next/dynamic';
+
+const DynamicPage = dynamic(() => import('./DynamicPage'), {
+  ssr: false,
+});
+
+export default function Page() {
+  return <DynamicPage />;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,6 +12,17 @@ body {
 }
 
 @layer utilities {
+  .scrollbar-hide {
+    /* IE and Edge */
+    -ms-overflow-style: none;
+    /* Firefox */
+    scrollbar-width: none;
+    /* Safari and Chrome */
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+  
   .text-balance {
     text-wrap: balance;
   }

--- a/src/components/input/InputWithErrorMsg.tsx
+++ b/src/components/input/InputWithErrorMsg.tsx
@@ -16,9 +16,11 @@ const InputWithError = forwardRef(function InputWithError({
   return (
     <div className="flex flex-col gap-2">
       <Input {...props} className={errorStyle} ref={ref as LegacyRef<HTMLInputElement>} />
-      <div className="h-8">
-        {hasError && <p className="text-v1-red-700 text-sm text-right">{errorMessage}</p>}
-      </div>
+      {hasError && (
+        <div className='h-8'>
+          <p className='text-v1-red-700 text-sm text-right'>{errorMessage}</p>
+        </div>
+      )}
     </div>
   );
 })

--- a/src/components/tab/LinkTabs.tsx
+++ b/src/components/tab/LinkTabs.tsx
@@ -1,18 +1,24 @@
 'use client';
 
-import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
+
 
 type LinkTab<T> = T extends Array<{ type: string; label: string; href: string }> ? T[number] : never;
 
 function LinkTabs<T extends Array<{ type: string; label: string; href: string }>>({
   tab,
   tabs,
+  className,
 }: {
   tab: LinkTab<T>['type'];
   tabs: T;
+  className?: string;
 }) {
   return (
-    <ul className='-mx-6 mt-4 flex h-12 justify-between border-b border-v1-text-primary-75'>
+    <ul
+      className={`-mx-6 mt-4 flex min-h-12 flex-wrap justify-between border-b border-v1-text-primary-75 ${className}`}
+    >
       {tabs.map((e) => (
         <TabLinkButton key={e.type} tab={e} currentTabType={tab} />
       ))}
@@ -28,14 +34,22 @@ function TabLinkButton<T extends { type: string; label: string; href: string }>(
   currentTabType: T['type'];
 }) {
   const isActive = tab.type === currentTabType;
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  const handleClick = () => {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('tab', tab.type);
+    router.push(`?${params.toString()}`);
+  };
 
   return (
     <li
-      className={`text-md flex h-full w-full items-center justify-center font-semibold ${isActive ? 'border-b-2 border-v1-text-primary-500' : 'text-v1-text-primary-200'}`}
+      className={`text-md flex h-12 flex-1 items-center justify-center font-semibold ${isActive ? 'border-b-2 border-v1-text-primary-500 pt-[2px]' : 'text-v1-text-primary-200'}`}
     >
-      <Link href={tab.href} className='flex h-full w-full items-center justify-center'>
+      <button onClick={handleClick} className='flex h-full w-full items-center justify-center whitespace-nowrap break-keep px-2'>
         {tab.label}
-      </Link>
+      </button>
     </li>
   );
 }

--- a/src/types/challenge.ts
+++ b/src/types/challenge.ts
@@ -21,3 +21,9 @@ export interface Participant {
   isCreator: boolean;
   avatar: string | null;
 }
+
+export type User = {
+  id: string;
+  name: string;
+  profileImageUrl: string;
+};


### PR DESCRIPTION
# 챌린지 검색 페이지

- 최근검색 리스트
![image](https://github.com/user-attachments/assets/95c1974b-9c58-4510-b34b-3141fec1e973)
- 검색결과 각 탭
![image](https://github.com/user-attachments/assets/426edffb-9670-4f53-9932-5263fef11a5f)
- 결과별 가로 스크롤 리스트
- [useSearch 훅 작성](https://github.com/Jak-Sim/client-web/blob/297b59beb3099d059363ce3a484d6d86ad81c607/src/app/(pages)/challenge/search/_hook/useSearch.ts) 

## 시연영상
https://github.com/user-attachments/assets/bda00dac-fa06-4817-a528-57af86a121f6

## 구현 상세

- searchParams는 tab과 search를 사용했습니다.
- 검색 디바운스: 200ms
- 스크롤 숨김을 위한 .scrollbar-hide CSS 클래스 추가했습니다.
- UI 오류가 있어서 공통 컴포넌트 InputWithErrorMsg, LinkTabs를 수정했습니다.
  - 줄바꿈, 여백, 박스모델 

## useSearch 단위테스트
<img width="775" alt="image" src="https://github.com/user-attachments/assets/36589c0b-e180-467a-9686-7070f59d163f" />

<img width="819" alt="image" src="https://github.com/user-attachments/assets/ed5f8463-c42a-4924-af1f-e6173264e7cb" />
