### PR TITLE
fix: 닉네임 중복확인 1)key 수정, 2)메시지 출력, 3)회원 가입 key 수정

### DIFF
--- a/src/app/(pages)/auth/sign-up/_components/SignUp.tsx
+++ b/src/app/(pages)/auth/sign-up/_components/SignUp.tsx
@@ -52,6 +52,7 @@ export default function SignUp() {
       social: sessionWithAccount.account.provider.toUpperCase(),
       userUniqueId: sessionWithAccount.account.providerAccountId,
     };
+
     const response = (await api.post('/sign-up', user)) as {
       data: { data: UserSignUpDto };
     };
@@ -72,16 +73,26 @@ export default function SignUp() {
   const checkUsernameUnique = useCallback(
     async (username: string) => {
       if (username?.length < 2) return;
+      let msg = '';
 
       try {
-        await api.post('/sign-up/nick-check', { nickname: username });
+        const response = await api.post('/sign-up/nick-check', { username });
+        msg = response.data as string;
+
+        if (msg.includes('이미')) {
+          setError('nickname', {
+            type: 'manual',
+            message: msg,
+          });
+          return false;
+        }
+
         return true;
       } catch (error) {
         if (error instanceof Error) {
-          // TODO: 중복된 닉네임 오류 특정하기, statusCode 확인
           setError('nickname', {
             type: 'manual',
-            message: error.message ?? '중복된 닉네임이에요. 다른 닉네임은 어떠신가요?',
+            message: error.message ?? '오류가 발생했습니다.',
           });
         }
         return false;

--- a/src/app/(pages)/auth/sign-up/_components/SignUp.tsx
+++ b/src/app/(pages)/auth/sign-up/_components/SignUp.tsx
@@ -50,7 +50,7 @@ export default function SignUp() {
       RT: sessionWithAccount.auth.RT,
       nickname: data.nickname,
       social: sessionWithAccount.account.provider.toUpperCase(),
-      userUniqueId: sessionWithAccount.account.providerAccountId,
+      socialUserId: sessionWithAccount.account.providerAccountId,
     };
 
     const response = (await api.post('/sign-up', user)) as {


### PR DESCRIPTION
# 닉네임 중복확인 버그 수정

## 1. 닉네임 중복확인 key 수정
- notion 기준 => swagger 기준으로 key 변경
nickname에서 username으로 변경했습니다. (일치하지 않은 키로 요청을 보냈을 때 200응답 받는 현상이 있어 확인이 늦음)
![image](https://github.com/user-attachments/assets/c5eb5bac-1797-4e5e-a0ba-304fa6cd09c9)

## 2. 닉네임 중복확인 메시지 출력
200대 요청일 때, 서버에서 "이미 존재하는 닉네임입니다." 텍스트를 반환했다면 에러 던지도록 수정
![image](https://github.com/user-attachments/assets/a0eae95c-74e6-4305-81f0-f7faacfcf8f4)

## 3. 회원 가입 key 수정
userUniqueId => socialUserId
